### PR TITLE
fix: pnpm v11 のビルドスクリプト承認設定を追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,16 +15,14 @@ RUN apk update && \
 
 WORKDIR /app
 
-COPY pnpm-lock.yaml ./
+COPY pnpm-lock.yaml package.json pnpm-workspace.yaml ./
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 
-COPY package.json tsconfig.json ./
+COPY tsconfig.json ./
 COPY src src
 
-ENV CI=true
-
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline
 
 ENV NODE_ENV=production
 ENV API_PORT=80

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN apk update && \
   echo "Asia/Tokyo" > /etc/timezone && \
   apk del tzdata && \
   npm install -g corepack@latest && \
-  pnpm approve-builds && \
   corepack enable
 
 WORKDIR /app
@@ -23,8 +22,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 COPY package.json tsconfig.json ./
 COPY src src
 
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline && \
-  pnpm approve-builds
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline
 
 ENV NODE_ENV=production
 ENV API_PORT=80

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY src src
 
 ENV CI=true
 
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 
 ENV NODE_ENV=production
 ENV API_PORT=80

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 COPY package.json tsconfig.json ./
 COPY src src
 
+ENV CI=true
+
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline
 
 ENV NODE_ENV=production

--- a/package.json
+++ b/package.json
@@ -76,10 +76,5 @@
       "jest-expect-message"
     ]
   },
-  "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
-  }
+  "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+packages:
+  - "."
 allowBuilds:
   esbuild: true
   unrs-resolver: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 allowBuilds:
   esbuild: true
+  unrs-resolver: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,3 @@
-packages:
-  - "."
 allowBuilds:
   esbuild: true
   unrs-resolver: true


### PR DESCRIPTION
## 概要

pnpm v11 へのアップデートに伴い、ビルドスクリプトのデフォルトブロック機能および Docker ビルドにおけるバージョン不一致問題への対応を行います。

## 変更内容

### 発生するエラー（対応前）

- `[ERR_PNPM_IGNORED_BUILDS]`: `pnpm install` でビルドスクリプトがブロックされる
- `[ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY]`: Docker ビルド環境でのバージョン不一致によりモジュール削除の確認が発生し、TTY がないため失敗

### 1. `pnpm-workspace.yaml` の追加

pnpm v11 では `pnpm.onlyBuiltDependencies`（package.json）が廃止され、`pnpm-workspace.yaml` の `allowBuilds` で管理するよう変更されました。

- `package.json` から `pnpm.onlyBuiltDependencies` を削除
- `pnpm-workspace.yaml` を新規作成し `allowBuilds` に esbuild・unrs-resolver を追加
- pnpm@9 との互換性のため `packages: ["."]` を追加（pnpm@9 は `packages` フィールドが必須）

```yaml
packages:
  - "."
allowBuilds:
  esbuild: true
  unrs-resolver: true
```

### 2. Dockerfile の修正

従来の Dockerfile では `pnpm fetch` 実行時に `package.json` が存在しないため corepack が pnpm@11 を使用し、その後 `pnpm install` 実行時に `package.json` が COPY されることで corepack が pnpm@10（`packageManager` フィールドの値）を使用します。このバージョン不一致により node_modules の削除確認プロンプトが表示されますが、Docker 環境には TTY がないため失敗します。

- COPY 順序を変更し、`pnpm fetch` 前に `package.json` と `pnpm-workspace.yaml` を COPY することで両ステップで同じ pnpm バージョンを使用するよう修正
- `pnpm approve-builds` の呼び出しを削除（`allowBuilds` 設定で代替）

```dockerfile
# 修正後の COPY 順序
COPY pnpm-lock.yaml package.json pnpm-workspace.yaml ./
RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
COPY tsconfig.json ./
COPY src src
RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline
```

### 3. Vercel 設定（プロジェクト設定で対応済み）

Vercel がプロジェクト作成日をもとに pnpm@9 を使用していたため、`ENABLE_EXPERIMENTAL_COREPACK=1` を Vercel プロジェクト設定に追加しました（`packageManager` フィールドの pnpm@10 が使用されるよう変更）。

## 関連

- book000/book000#108

🤖 Generated with [Claude Code](https://claude.com/claude-code)