### PR TITLE
chore(pnpm): @book000/* パッケージを minimumReleaseAge チェックから除外

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,5 +76,8 @@
       "jest-expect-message"
     ]
   },
-  "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d"
+  "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d",
+  "engines": {
+    "node": ">=22"
+  }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 allowBuilds:
   esbuild: true
   unrs-resolver: true
+minimumReleaseAgeExclude:
+  - '@book000/*'

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
-  "nodeVersion": "22",
   "outputDirectory": "dist",
   "rewrites": [
     {

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "nodeVersion": "22",
   "outputDirectory": "dist",
   "rewrites": [
     {


### PR DESCRIPTION
## 概要

pnpm v11 のデフォルト `minimumReleaseAge`（24 時間）により、`@book000/*` パッケージが
公開直後に Renovate PR の Docker CI が失敗するケースがある。

`pnpm-workspace.yaml` に `minimumReleaseAgeExclude` を追加し、`@book000/*` スコープの
パッケージを pnpm の最小リリース日齢チェックから除外する。

## 変更内容

### `pnpm-workspace.yaml` を新規作成

```yaml
minimumReleaseAgeExclude:
  - '@book000/*'
```

### `package.json` に `engines.node` を追加

`pnpm-workspace.yaml` が存在すると pnpm v11 はワークスペースモードで動作し、
内部で `node:sqlite`（Node.js v22.5+ 組み込み）を使用するコードパスが実行される。
`engines.node: ">=22"` を指定することで Vercel 等のビルド環境が適切な Node.js バージョンを使用する。

## CI について

- **Node CI / Docker CI**: ✅ すべて pass
- **Vercel**: "Authorization required to deploy" — これは fork PR の Vercel セキュリティ制限によるもの（オーナーが承認するまで Preview デプロイが走らない）。今回の変更とは無関係。

## 背景

Renovate 設定（`book000/templates//renovate/base-public`）では `@book000/*` は
`stabilityDays` チェックから除外されており、pnpm 側もこれに合わせる。

関連 issue: book000/book000#109