### PR TITLE
feat: TypeScript v6 マイグレーション対応

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "commonjs",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "lib": ["ESNext", "esnext.AsyncIterable"],
     "outDir": "./dist",
     "removeComments": true,
@@ -22,9 +22,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
     "rootDir": ".",
-    "ignoreDeprecations": "6.0",
     "types": ["node", "jest"],
     "newLine": "LF"
   },


### PR DESCRIPTION
## 概要

TypeScript v6.0 へのアップグレードに伴うテンポラリ対応 (`ignoreDeprecations: "6.0"`) を恒久対応に切り替えます。

## 変更内容

### `tsconfig.json` の修正

1. **`moduleResolution` の更新**: `"Node"` → `"bundler"`
   - TypeScript v6 では `"Node"` が廃止予定のため、CommonJS モジュールに対応した推奨設定に変更
2. **`baseUrl` の削除**: `"baseUrl": "."` を削除
   - プロジェクトが `paths` 設定を使用していないため不要
3. **`ignoreDeprecations` の削除**: `"ignoreDeprecations": "6.0"` を削除
   - TypeScript 7.0 ではこの設定が認識されなくなるため、根本対応として削除

## 動作確認

- `pnpm build` が正常に通ることを確認済み
- `pnpm lint` (prettier / eslint / tsc) が正常に通ることを確認済み

Fixes #2578