### PR TITLE
fix: Discord メッセージ送信時に ID が取得できない場合のキャッシュ登録を防ぐ

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -55,10 +55,14 @@ export abstract class BaseAction<T extends Schema> {
     }
 
     // それ以外の場合は新規に送信する
+    // sendMessage() は Webhook が 204 No Content を返した場合に undefined を返すため、
+    // メッセージ ID が取得できた場合のみキャッシュに保存する
     const sentMessageId = await this.discord.sendMessage(message)
-    this.messageCache[key] = {
-      messageId: sentMessageId,
-      timestamp: Date.now(),
+    if (sentMessageId) {
+      this.messageCache[key] = {
+        messageId: sentMessageId,
+        timestamp: Date.now(),
+      }
     }
   }
 }


### PR DESCRIPTION
## 概要

@book000/node-utils の `Discord.sendMessage()` は、Webhook が `204 No Content` を返した場合に `undefined` を返す仕様です（戻り値の型は以前から `Promise<string | undefined>`）。

現在の `@book000/node-utils` バージョン (1.24.123) では何故かこの型が `Promise<string>` として公開されていましたが、最新版 (1.24.224) では正しく `Promise<string | undefined>` に修正されており、これにより `@book000/node-utils` を v1.24.224 に更新する Renovate PR (#2439) で以下の型エラーが発生し CI が失敗しています。

```
src/actions/index.ts:60:7 - error TS2322: Type 'string | undefined' is not assignable to type 'string'.
  Type 'undefined' is not assignable to type 'string'.
```

## 修正内容

- `BaseAction.sendMessage()` 内で、`sendMessage()` の戻り値（メッセージ ID）が `undefined` の場合はメッセージキャッシュに登録しないように修正しました
  - メッセージ ID が取得できない場合、後続の編集処理（5 分以内の同キーでの再送時に `editMessage` を呼ぶ処理）が成立しないため、キャッシュに登録しないのが妥当と判断しました

## 動作確認

- `pnpm lint`（prettier / eslint / tsc）が成功することを確認しました
- ローカルで `@book000/node-utils@1.24.224` に一時的に更新し、`pnpm run lint:tsc` が成功することを確認しました（この変更自体には依存パッケージの更新は含めていません）

この修正がマージされることで、#2439 が Renovate によりリベースされた際に CI が成功するようになります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)