### PR TITLE
fix: eslint-plugin-unicorn v65 の新規ルール違反を修正

### DIFF
--- a/src/actions/issues.ts
+++ b/src/actions/issues.ts
@@ -505,8 +505,9 @@ export class IssuesAction extends BaseAction<IssuesEvent> {
     // プルリク作成時、再オープン時、アサイン時にメンションを付ける
     const assignees = issue.assignees
 
-    const isNeedAssigneeMention =
-      action === 'opened' || action === 'reopened' || action === 'assigned'
+    const isNeedAssigneeMention = ['opened', 'reopened', 'assigned'].includes(
+      action
+    )
 
     const assigneesMentions = isNeedAssigneeMention
       ? await getUsersMentions(sender, assignees)

--- a/src/actions/push.ts
+++ b/src/actions/push.ts
@@ -32,7 +32,7 @@ export class PushAction extends BaseAction<PushEvent> {
       .map((commit) => {
         const { id, url, message, author } = commit
         const firstLine = message.includes('\n')
-          ? message.split('\n')[0]
+          ? message.split('\n', 2)[0]
           : message
         const shortMessage =
           firstLine.length > 50 ? `${firstLine.slice(0, 50)}...` : firstLine


### PR DESCRIPTION
## 概要

`@book000/eslint-config` v1.14.59 への更新 (#2574) に伴い有効化された `eslint-plugin-unicorn` v65 系の新規ルールに対して、違反箇所を修正します。

Fixes #2583

## 変更内容

### `src/actions/issues.ts` — `unicorn/prefer-includes-over-repeated-comparisons`

繰り返し等値比較を `.includes()` に変更しました。

```diff
- const isNeedAssigneeMention =
-   action === 'opened' || action === 'reopened' || action === 'assigned'
+ const isNeedAssigneeMention = ['opened', 'reopened', 'assigned'].includes(action)
```

### `src/actions/push.ts` — `unicorn/prefer-split-limit`

`String#split()` に `limit` 引数を追加しました。

```diff
- ? message.split('\n')[0]
+ ? message.split('\n', 2)[0]
```

## 確認事項

- [x] `pnpm lint` (v1.14.55・v1.14.59 双方) パス
- [x] `pnpm test` パス (65 tests passed)
- [x] `pnpm build` (tsc) パス
- [x] Renovate PR (#2574) には直接コミットしていない