### PR TITLE
fix: devcontainer から pnpm approve-builds を削除

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   "otherPortsAttributes": {
     "onAutoForward": "silent"
   },
-  "postCreateCommand": "sudo npm uninstall -g pnpm yarn && sudo chown node node_modules .pnpm-store && sudo npm install -g corepack@latest && sudo corepack enable && corepack install && pnpm install && pnpm approve-builds",
+  "postCreateCommand": "sudo npm uninstall -g pnpm yarn && sudo chown node node_modules .pnpm-store && sudo npm install -g corepack@latest && sudo corepack enable && corepack install && pnpm install",
   "waitFor": "postStartCommand",
   "mounts": [
     "source=${localWorkspaceFolderBasename}-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume",


### PR DESCRIPTION
## 概要

devcontainer の `postCreateCommand` から `pnpm approve-builds` を削除します。

## 背景

pnpm v10 以降、lifecycle script を持つパッケージは `pnpm-workspace.yaml` の `allowBuilds` で事前に許可することで、`pnpm install` 実行時に自動的にスクリプトが実行されます。

`pnpm approve-builds` を明示的に呼ぶ必要はなくなりました。

関連: book000/book000#119

🤖 Generated with [Claude Code](https://claude.com/claude-code)