### PR TITLE
fix: Azure Functions デプロイワークフローが起動しない不具合を修正

### DIFF
--- a/.github/workflows/azure-functions-deploy.yml
+++ b/.github/workflows/azure-functions-deploy.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+
+concurrency:
+  group: azure-deploy
+  cancel-in-progress: true
 
 permissions: {}
 
@@ -16,39 +21,42 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
 
-    environment:
-      name: production
-      url: https://${{ secrets.AZURE_FUNCTIONAPP_NAME }}.azurewebsites.net
+    # NOTE: jobs.<job_id>.environment.url では secrets コンテキストが使用できず、
+    #       ワークフロー自体が invalid 判定されジョブが起動しなくなるため指定しない
+    environment: production
 
     permissions:
       id-token: write
       contents: read
 
     steps:
-      - name: Checkout
+      - name: 🛎 Checkout
         uses: actions/checkout@v4
 
-      - name: Login to Azure (OIDC)
+      - name: 🔑 Login to Azure (OIDC)
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Setup .NET SDK
+      - name: 🏗 Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+          cache: true
+          cache-dependency-path: "**/*.csproj"
 
-      - name: Restore dependencies
+      - name: 📦 Restore dependencies
         run: dotnet restore src/GitHubWebhookBridge.csproj
 
-      - name: Publish
+      - name: 🏗 Publish
         run: dotnet publish src/GitHubWebhookBridge.csproj --configuration Release --no-restore --output ${{ env.PUBLISH_OUTPUT_DIR }}
 
-      - name: Deploy to Azure Functions
+      - name: 🚀 Deploy to Azure Functions
         uses: Azure/functions-action@v1
         with:
           app-name: ${{ secrets.AZURE_FUNCTIONAPP_NAME }}
           package: ${{ env.PUBLISH_OUTPUT_DIR }}
+          scm-do-build-during-deployment: false
 

--- a/.github/workflows/azure-functions-deploy.yml
+++ b/.github/workflows/azure-functions-deploy.yml
@@ -21,8 +21,6 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
 
-    # NOTE: jobs.<job_id>.environment.url では secrets コンテキストが使用できず、
-    #       ワークフロー自体が invalid 判定されジョブが起動しなくなるため指定しない
     environment: production
 
     permissions:


### PR DESCRIPTION
## 概要

master へのマージ後、Azure Functions へのデプロイが一切実行されていなかった不具合を修正する。

## 原因

`.github/workflows/azure-functions-deploy.yml` の `jobs.deploy.environment.url` に `secrets.AZURE_FUNCTIONAPP_NAME` を参照していたが、GitHub Actions の仕様上 `jobs.<job_id>.environment.url` では `secrets` コンテキストを使用できない([Context availability](https://docs.github.com/en/actions/learn-github-actions/contexts) 参照、利用可能なのは `github, needs, strategy, matrix, job, runner, env, vars, steps, inputs` のみ)。

このためワークフローファイル自体が invalid 判定となり、push のたびにジョブが 1 つも起動せず即座に失敗していた(実行履歴上もジョブ数 0 件の `failure`)。

## 変更内容

- `environment.url` を削除し、`environment: production` のみを指定
- `workflow_dispatch` トリガーを追加し、手動再実行を可能にする
- `concurrency` を追加し、同時デプロイを防止する
- `actions/setup-dotnet` のキャッシュを有効化
- `Azure/functions-action` に `scm-do-build-during-deployment: false` を明示
- ステップ名に絵文字プレフィックスを付与(プロジェクトの GitHub Actions コーディング規約に準拠)

参考: [tomacheese/watch-wishlist-sale の azure-functions-deploy.yml](https://github.com/tomacheese/watch-wishlist-sale/blob/master/.github/workflows/azure-functions-deploy.yml)

## 確認事項

- `python3 -c "import yaml; yaml.safe_load(...)"` で YAML 構文を確認済み
- ローカルに dotnet 環境がないため実ビルド・実デプロイの確認は未実施。マージ後の GitHub Actions 実行結果で確認が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)
