### PR TITLE
fix: ActionFactory の DI 登録漏れによる起動時クラッシュを修正

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -49,7 +49,10 @@ builder.Services
     // CAPTIVE DEPENDENCY GUARD: ActionFactory が受け取る IServiceProvider は root SP。
     // Action の依存はすべて Singleton であること。
     // Scoped サービスを Action に追加した場合は IServiceScopeFactory を使う設計に変更すること。
-    .AddSingleton<IActionFactory, ActionFactory>()
+    // ActionFactory をクラス直接・インターフェースの両方で登録
+    // （ActionRegistryValidator が具象型 ActionFactory を直接注入できるようにするため）
+    .AddSingleton<ActionFactory>()
+    .AddSingleton<IActionFactory>(sp => sp.GetRequiredService<ActionFactory>())
     // 起動時にアクションレジストリの DI 解決を検証
     .AddHostedService<ActionRegistryValidator>()
     // テーブルストレージの初期化をホスト起動時に非同期実行


### PR DESCRIPTION
## 概要

デプロイ後、Azure Functions の起動時に以下の例外でクラッシュし、関数が一切動作していなかった不具合を修正する。

```
Microsoft.Azure.WebJobs.Script.Grpc: ... dotnet.exe exited with code -532462766 (0xE0434352).
Unhandled exception. System.InvalidOperationException: Unable to resolve service for type
'GitHubWebhookBridge.Actions.ActionFactory' while attempting to activate
'GitHubWebhookBridge.Services.ActionRegistryValidator'.
```

## 原因

`Program.cs` で `ActionFactory` を `AddSingleton<IActionFactory, ActionFactory>()` のように **インターフェース経由でのみ** DI 登録していた。

一方、起動時検証用の `ActionRegistryValidator` のプライマリコンストラクタは具象型 `ActionFactory` を直接要求している(`ActionRegistryValidator(ActionFactory factory, IServiceProvider sp)`)。.NET の標準 DI コンテナはインターフェース登録から具象型を自動解決しないため、`IHostedService` 起動時に `InvalidOperationException` が発生しプロセスごとクラッシュしていた。

`tests/ActionFactoryTests.cs` は `ActionFactory` を直接 `new` してテストしているため、この DI 登録漏れは検出できていなかった。

## 修正内容

`MessageCacheService` で既に使われているパターン(具象型をクラス直接登録し、インターフェースはそれを参照する)に合わせ、`ActionFactory` も同様に修正した。

```csharp
.AddSingleton<ActionFactory>()
.AddSingleton<IActionFactory>(sp => sp.GetRequiredService<ActionFactory>())
```

## 確認事項

- 他に具象型を直接要求しているクラスは `TableStorageInitializer(MessageCacheService)` のみで、こちらは既に正しく登録済みであることを確認した
- ローカルに dotnet 環境がないため `dotnet build` / `dotnet test` は未実施。CI(`dotnet-ci.yml`)での確認が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)
