### PR TITLE
fix: GET / でも稼働確認レスポンスを返すように対応

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,8 @@ cd src && func start              # run Azure Functions locally
 5. `Managers/MuteManager.cs` checks mute rules (include / exclude / all modes).
 6. `BaseAction.SendMessageAsync(key, message)` sends via `DiscordClient`; if the same key was sent within the last 5 minutes, it **edits** the existing Discord message instead. On edit failure the cache entry is deleted and a new message is sent. Every message has `SuppressNotifications` forced on.
 
+`GET /` is handled separately by `Functions/RootFunction.cs` (same route regex, `"get"` method) and returns a `200 OK` health-check style JSON body — this avoids the Azure Functions default placeholder homepage ("Your Functions x.x app is up and running") that would otherwise appear for unmatched methods on the root route. Shared `{ "message": ... }` JSON response building lives in `Utils/JsonResponseHelper.cs`, used by both `WebhookFunction` and `RootFunction`.
+
 **Key patterns**
 
 - `BaseAction<TEvent>` — generic abstract base; `abstract Task RunAsync()`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 GitHub Webhook を受信して Discord に転送する Azure Functions アプリケーション。
 
-- **エンドポイント**: `POST /`
+- **エンドポイント**: `POST /`（Webhook 受信）、`GET /`（稼働確認）
 - **スタック**: C# / .NET 10 / Azure Functions v4 Isolated / Azure Table + Blob Storage
 - **署名検証**: HMAC-SHA256（`x-hub-signature-256`、タイミングセーフ比較）
 
@@ -55,6 +55,8 @@ cd src && func start
 |------|-----|
 | 本番 | `POST https://<functionapp>.azurewebsites.net/` |
 | ローカル | `POST http://localhost:7071/` |
+
+`GET /` にアクセスすると、稼働確認用に `200 OK` と `{ "message": "book000/github-webhook-bridge is running" }` を返します。
 
 ### クエリパラメータ
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ cd src && func start
 
 | 環境 | URL |
 |------|-----|
-| 本番 | `POST https://<functionapp>.azurewebsites.net/` |
-| ローカル | `POST http://localhost:7071/` |
+| 本番 | `https://<functionapp>.azurewebsites.net/` |
+| ローカル | `http://localhost:7071/` |
 
-`GET /` にアクセスすると、稼働確認用に `200 OK` と `{ "message": "book000/github-webhook-bridge is running" }` を返します。
+- `POST /`（Webhook 受信）: GitHub Webhook イベントを受信し、Discord に転送します。
+- `GET /`（稼働確認）: `200 OK` と `{ "message": "book000/github-webhook-bridge is running" }` を返します。
 
 ### クエリパラメータ
 

--- a/src/Functions/RootFunction.cs
+++ b/src/Functions/RootFunction.cs
@@ -1,0 +1,30 @@
+using System.Net;
+using GitHubWebhookBridge.Utils;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+
+namespace GitHubWebhookBridge.Functions;
+
+/// <summary>ルートパスへの GET リクエストに応答する Azure Functions のクラス</summary>
+/// <remarks>
+/// <see cref="WebhookFunction"/> は POST のみを受け付けるため、GET でルートパスにアクセスすると
+/// どの Function にもマッチせず、Azure Functions の既定プレースホルダーページ
+/// （"Your Functions x.x app is up and running"）が表示されてしまう。
+/// これを避けるため、GET 専用の Function を別途用意し、稼働確認用の簡易なレスポンスを返す
+/// </remarks>
+public static class RootFunction
+{
+    /// <summary>
+    /// ルートパスへの GET リクエストを受け取り、稼働確認用のレスポンスを返す
+    /// </summary>
+    /// <remarks>
+    /// <c>Route = ""</c>（空文字）は <c>routePrefix = ""</c> と組み合わせても関数名にフォールバックしてしまう
+    /// 既知の挙動のため使用しない。<see cref="WebhookFunction"/> と同様に正規表現で空セグメントにマッチさせる
+    /// </remarks>
+    /// <param name="req">Azure Functions が受け取った HTTP リクエスト</param>
+    /// <returns>稼働確認用のレスポンスを表す <see cref="HttpResponseData"/></returns>
+    [Function("Root")]
+    public static async Task<HttpResponseData> RunAsync(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "{x:regex(^$)?}")] HttpRequestData req)
+        => await JsonResponseHelper.CreateAsync(req, HttpStatusCode.OK, "book000/github-webhook-bridge is running").ConfigureAwait(false);
+}

--- a/src/Functions/RootFunction.cs
+++ b/src/Functions/RootFunction.cs
@@ -5,22 +5,14 @@ using Microsoft.Azure.Functions.Worker.Http;
 
 namespace GitHubWebhookBridge.Functions;
 
-/// <summary>ルートパスへの GET リクエストに応答する Azure Functions のクラス</summary>
-/// <remarks>
-/// <see cref="WebhookFunction"/> は POST のみを受け付けるため、GET でルートパスにアクセスすると
-/// どの Function にもマッチせず、Azure Functions の既定プレースホルダーページ
-/// （"Your Functions x.x app is up and running"）が表示されてしまう。
-/// これを避けるため、GET 専用の Function を別途用意し、稼働確認用の簡易なレスポンスを返す
-/// </remarks>
+/// <summary>
+/// ルートパスへの GET リクエストに応答する Azure Functions のクラス。
+/// <see cref="WebhookFunction"/>（POST 専用）にマッチしない GET リクエストが
+/// Azure Functions の既定プレースホルダーページに落ちるのを防ぐ
+/// </summary>
 public static class RootFunction
 {
-    /// <summary>
-    /// ルートパスへの GET リクエストを受け取り、稼働確認用のレスポンスを返す
-    /// </summary>
-    /// <remarks>
-    /// <c>Route = ""</c>（空文字）は <c>routePrefix = ""</c> と組み合わせても関数名にフォールバックしてしまう
-    /// 既知の挙動のため使用しない。<see cref="WebhookFunction"/> と同様に正規表現で空セグメントにマッチさせる
-    /// </remarks>
+    /// <summary>ルートパスへの GET リクエストを受け取り、稼働確認用のレスポンスを返す</summary>
     /// <param name="req">Azure Functions が受け取った HTTP リクエスト</param>
     /// <returns>稼働確認用のレスポンスを表す <see cref="HttpResponseData"/></returns>
     [Function("Root")]

--- a/src/Functions/WebhookFunction.cs
+++ b/src/Functions/WebhookFunction.cs
@@ -53,7 +53,7 @@ public class WebhookFunction(
 
         // Content-Length ヘッダーは偽装され得るため、宣言値の事前チェックに加えて実読み取りバイト数でも上限を再チェックする
         if (TryGetContentLength(req, out var declaredLength) && declaredLength > MaxBodyBytes)
-            return await CreateJsonResponseAsync(req, HttpStatusCode.BadRequest, "Bad Request: Body too large").ConfigureAwait(false);
+            return await JsonResponseHelper.CreateAsync(req, HttpStatusCode.BadRequest, "Bad Request: Body too large").ConfigureAwait(false);
 
         using var ms = new MemoryStream();
         var chunk = new byte[81920];
@@ -62,30 +62,30 @@ public class WebhookFunction(
         {
             await ms.WriteAsync(chunk.AsMemory(0, bytesRead)).ConfigureAwait(false);
             if (ms.Length > MaxBodyBytes)
-                return await CreateJsonResponseAsync(req, HttpStatusCode.BadRequest, "Bad Request: Body too large").ConfigureAwait(false);
+                return await JsonResponseHelper.CreateAsync(req, HttpStatusCode.BadRequest, "Bad Request: Body too large").ConfigureAwait(false);
         }
 
         var rawBody = ms.ToArray();
 
         if (rawBody.Length == 0)
-            return await CreateJsonResponseAsync(req, HttpStatusCode.BadRequest, "Bad Request: Empty body").ConfigureAwait(false);
+            return await JsonResponseHelper.CreateAsync(req, HttpStatusCode.BadRequest, "Bad Request: Empty body").ConfigureAwait(false);
 
         var secret = _config["GITHUB_WEBHOOK_SECRET"]
             ?? throw new InvalidOperationException("GITHUB_WEBHOOK_SECRET not set");
         var signatureHeader = GetHeaderValue(req, "X-Hub-Signature-256");
         if (!SignatureValidator.Validate(rawBody, signatureHeader, secret))
-            return await CreateJsonResponseAsync(req, HttpStatusCode.BadRequest, "Bad Request: Invalid X-Hub-Signature-256").ConfigureAwait(false);
+            return await JsonResponseHelper.CreateAsync(req, HttpStatusCode.BadRequest, "Bad Request: Invalid X-Hub-Signature-256").ConfigureAwait(false);
 
         // ログインジェクション防止のため、許可文字以外を含む X-GitHub-Event ヘッダーは拒否する
         var rawEventName = GetHeaderValue(req, "X-GitHub-Event");
         if (string.IsNullOrEmpty(rawEventName))
-            return await CreateJsonResponseAsync(req, HttpStatusCode.BadRequest, "Bad Request: Missing X-GitHub-Event").ConfigureAwait(false);
+            return await JsonResponseHelper.CreateAsync(req, HttpStatusCode.BadRequest, "Bad Request: Missing X-GitHub-Event").ConfigureAwait(false);
 
         var sanitizedEventName = SanitizeEventName(rawEventName);
         if (sanitizedEventName != rawEventName)
         {
             _logger.LogWarning("Rejected request with invalid X-GitHub-Event header value");
-            return await CreateJsonResponseAsync(req, HttpStatusCode.BadRequest, "Bad Request: Invalid X-GitHub-Event").ConfigureAwait(false);
+            return await JsonResponseHelper.CreateAsync(req, HttpStatusCode.BadRequest, "Bad Request: Invalid X-GitHub-Event").ConfigureAwait(false);
         }
 
         // ActionFactory のリフレクションレジストリは Ordinal 比較のため小文字に正規化する
@@ -97,7 +97,7 @@ public class WebhookFunction(
         if (!string.IsNullOrEmpty(urlParam))
         {
             if (!IsAllowedWebhookUrl(urlParam))
-                return await CreateJsonResponseAsync(req, HttpStatusCode.BadRequest, "Bad Request: Invalid url parameter").ConfigureAwait(false);
+                return await JsonResponseHelper.CreateAsync(req, HttpStatusCode.BadRequest, "Bad Request: Invalid url parameter").ConfigureAwait(false);
             webhookUrl = new Uri(urlParam);
         }
         else
@@ -116,7 +116,7 @@ public class WebhookFunction(
         {
             var disabledEventNames = disabledEvents.Split(',', StringSplitOptions.RemoveEmptyEntries);
             if (disabledEventNames.Contains(eventName, StringComparer.OrdinalIgnoreCase))
-                return await CreateJsonResponseAsync(req, HttpStatusCode.Accepted, "Disabled event").ConfigureAwait(false);
+                return await JsonResponseHelper.CreateAsync(req, HttpStatusCode.Accepted, "Disabled event").ConfigureAwait(false);
         }
 
         // デシリアライズ前に JSON として妥当か確認しつつ、後続処理のために raw string も保持する
@@ -126,11 +126,11 @@ public class WebhookFunction(
             rawJson = Encoding.UTF8.GetString(rawBody);
             using var doc = JsonDocument.Parse(rawJson);
             if (doc.RootElement.ValueKind != JsonValueKind.Object)
-                return await CreateJsonResponseAsync(req, HttpStatusCode.BadRequest, "Bad Request: JSON body must be an object").ConfigureAwait(false);
+                return await JsonResponseHelper.CreateAsync(req, HttpStatusCode.BadRequest, "Bad Request: JSON body must be an object").ConfigureAwait(false);
         }
         catch (JsonException)
         {
-            return await CreateJsonResponseAsync(req, HttpStatusCode.BadRequest, "Bad Request: Invalid JSON body").ConfigureAwait(false);
+            return await JsonResponseHelper.CreateAsync(req, HttpStatusCode.BadRequest, "Bad Request: Invalid JSON body").ConfigureAwait(false);
         }
 
         await _muteManager.EnsureLoadedAsync().ConfigureAwait(false);
@@ -146,7 +146,7 @@ public class WebhookFunction(
         if (envelope?.Sender?.Id is { } senderId)
         {
             if (_muteManager.IsMuted(senderId, eventName, envelope.Action))
-                return await CreateJsonResponseAsync(req, HttpStatusCode.OK, "Muted user").ConfigureAwait(false);
+                return await JsonResponseHelper.CreateAsync(req, HttpStatusCode.OK, "Muted user").ConfigureAwait(false);
         }
 
         IAction actionHandler;
@@ -158,7 +158,7 @@ public class WebhookFunction(
         {
             // 未実装イベント（スタブ以外の未知のイベント）は 400 を返す
             _logger.LogWarning("Unknown event type: {EventName}", eventName);
-            return await CreateJsonResponseAsync(req, HttpStatusCode.BadRequest, $"Bad Request: Unknown event '{eventName}'").ConfigureAwait(false);
+            return await JsonResponseHelper.CreateAsync(req, HttpStatusCode.BadRequest, $"Bad Request: Unknown event '{eventName}'").ConfigureAwait(false);
         }
 
         try
@@ -170,7 +170,7 @@ public class WebhookFunction(
         {
             // スタブアクションはまだ実装されていないため 406 を返す
             _logger.LogInformation("Method not implemented for event: {EventName}", eventName);
-            return await CreateJsonResponseAsync(req, HttpStatusCode.NotAcceptable, "Method not implemented").ConfigureAwait(false);
+            return await JsonResponseHelper.CreateAsync(req, HttpStatusCode.NotAcceptable, "Method not implemented").ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -197,21 +197,6 @@ public class WebhookFunction(
     /// <summary>指定ヘッダーの値を取得する。未設定の場合は <see langword="null"/> を返す</summary>
     private static string? GetHeaderValue(HttpRequestData req, string name)
         => req.Headers.TryGetValues(name, out IEnumerable<string>? values) ? values.FirstOrDefault() : null;
-
-    /// <summary>
-    /// <c>{ "message": ... }</c> 形式の JSON レスポンスを生成する。
-    /// <see cref="HttpResponseData.WriteAsJsonAsync{T}(T, CancellationToken)"/> は
-    /// <c>WorkerOptions.Serializer</c> の DI 解決に依存するため、
-    /// それを必要としない <c>WriteStringAsync</c> ベースで明示的にシリアライズする
-    /// </summary>
-    private static async Task<HttpResponseData> CreateJsonResponseAsync(HttpRequestData req, HttpStatusCode statusCode, string message)
-    {
-        HttpResponseData response = req.CreateResponse(statusCode);
-        response.Headers.Add("Content-Type", "application/json; charset=utf-8");
-        var json = JsonSerializer.Serialize(new { message });
-        await response.WriteStringAsync(json).ConfigureAwait(false);
-        return response;
-    }
 
     /// <summary>
     /// GitHub イベント名として有効な文字（英小文字・アンダースコア・ハイフン・英数字）のみ許可する。

--- a/src/Utils/JsonResponseHelper.cs
+++ b/src/Utils/JsonResponseHelper.cs
@@ -1,0 +1,28 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.Azure.Functions.Worker.Http;
+
+namespace GitHubWebhookBridge.Utils;
+
+/// <summary>Azure Functions の <see cref="HttpResponseData"/> に <c>{ "message": ... }</c> 形式の JSON を書き込むユーティリティクラス</summary>
+public static class JsonResponseHelper
+{
+    /// <summary>
+    /// <c>{ "message": ... }</c> 形式の JSON レスポンスを生成する。
+    /// <see cref="HttpResponseData.WriteAsJsonAsync{T}(T, CancellationToken)"/> は
+    /// <c>WorkerOptions.Serializer</c> の DI 解決に依存するため、
+    /// それを必要としない <c>WriteStringAsync</c> ベースで明示的にシリアライズする
+    /// </summary>
+    /// <param name="req">レスポンス生成元の HTTP リクエスト</param>
+    /// <param name="statusCode">レスポンスの HTTP ステータスコード</param>
+    /// <param name="message">レスポンスボディの <c>message</c> フィールドに設定する文字列</param>
+    /// <returns>生成された <see cref="HttpResponseData"/></returns>
+    public static async Task<HttpResponseData> CreateAsync(HttpRequestData req, HttpStatusCode statusCode, string message)
+    {
+        HttpResponseData response = req.CreateResponse(statusCode);
+        response.Headers.Add("Content-Type", "application/json; charset=utf-8");
+        var json = JsonSerializer.Serialize(new { message });
+        await response.WriteStringAsync(json).ConfigureAwait(false);
+        return response;
+    }
+}

--- a/tests/FakeHttp.cs
+++ b/tests/FakeHttp.cs
@@ -29,7 +29,8 @@ internal sealed class FakeHttpRequestData(
     FunctionContext functionContext,
     Stream body,
     HttpHeadersCollection headers,
-    NameValueCollection query)
+    NameValueCollection query,
+    string method = "POST")
     : HttpRequestData(functionContext)
 {
     public override Stream Body { get; } = body;
@@ -37,7 +38,7 @@ internal sealed class FakeHttpRequestData(
     public override IReadOnlyCollection<IHttpCookie> Cookies { get; } = [];
     public override Uri Url { get; } = new("https://gwb.tomacheese.com/");
     public override IEnumerable<ClaimsIdentity> Identities { get; } = [];
-    public override string Method { get; } = "POST";
+    public override string Method { get; } = method;
     public override NameValueCollection Query { get; } = query;
 
     public override HttpResponseData CreateResponse() => new FakeHttpResponseData(FunctionContext);

--- a/tests/RootFunctionTests.cs
+++ b/tests/RootFunctionTests.cs
@@ -1,0 +1,31 @@
+using System.Collections.Specialized;
+using System.Net;
+using System.Text;
+using GitHubWebhookBridge.Functions;
+using Microsoft.Azure.Functions.Worker.Http;
+
+namespace GitHubWebhookBridge.Tests;
+
+/// <summary>RootFunction.RunAsync() のテスト。</summary>
+public class RootFunctionTests
+{
+    /// <summary>レスポンスボディを UTF-8 文字列として読み出す。</summary>
+    private static string ReadBody(HttpResponseData response)
+    {
+        var stream = (MemoryStream)response.Body;
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    /// <summary>GET リクエストは 200 OK と稼働確認メッセージを返す。</summary>
+    [Fact]
+    public async Task RunGetRequestReturns200WithMessage()
+    {
+        var context = new FakeFunctionContext();
+        HttpRequestData req = new FakeHttpRequestData(context, new MemoryStream(), [], new NameValueCollection(), "GET");
+
+        HttpResponseData result = await RootFunction.RunAsync(req);
+
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Contains("book000/github-webhook-bridge is running", ReadBody(result), StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## 概要

`WebhookFunction` は `POST /` のみを受け付けるため、`GET /` にアクセスするとどの Function にもマッチせず、Azure Functions の既定プレースホルダーページ（"Your Functions x.x app is up and running"）が表示されてしまう問題を修正します。

Closes #2646

## 変更内容

- `GET /` 専用の `RootFunction` を新設し、`200 OK` と `{ "message": "book000/github-webhook-bridge is running" }` を返すようにした
- `WebhookFunction` とのレスポンス生成ロジック重複を避けるため、JSON レスポンス生成部分を `Utils/JsonResponseHelper.cs` に共通化した
- `WebhookFunction` は既存の動作を変えず、新しいヘルパーを使うようリファクタリング
- `README.md` / `CLAUDE.md` を更新

## 設計メモ

`WebhookFunction`（POST 専用）とは別に `RootFunction`（GET 専用）を新設する方針としました。同一ルート正規表現に GET/POST それぞれ専用の `Function` クラスを登録する構成が、C#/.NET Isolated Worker で確実にルーティングされることを Docker + Azure Functions Core Tools を使って実地検証済みです。

## テスト

- `dotnet build -c Release`: ビルド成功、既存の警告のみ（新規コード由来の警告なし）
- `dotnet test -c Release`: 130/130 件成功（`RootFunctionTests` を新規追加）