### PR TITLE
fix: Discord 429 の有界リトライと pull_request_review_thread の NullReferenceException を修正

### DIFF
--- a/src/Actions/Impl/PullRequestReviewThreadAction.cs
+++ b/src/Actions/Impl/PullRequestReviewThreadAction.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using GitHubWebhookBridge.Managers;
 using GitHubWebhookBridge.Models.Discord;
 using GitHubWebhookBridge.Services;
@@ -6,7 +7,6 @@ using Microsoft.Extensions.Logging;
 using Octokit.Webhooks;
 using Octokit.Webhooks.Events;
 using Octokit.Webhooks.Models;
-using OctokitReview = Octokit.Webhooks.Models.PullRequestReviewEvent.Review;
 
 namespace GitHubWebhookBridge.Actions.Impl;
 
@@ -26,9 +26,11 @@ public sealed class PullRequestReviewThreadAction(
     /// <inheritdoc/>
     public override async Task RunAsync()
     {
-        // Octokit の PullRequestReviewThreadEvent には Thread プロパティが存在しない。
-        // Review.NodeId をスレッド識別子として使用し、解決状態はアクションから導出する。
-        OctokitReview review = Event.Review;
+        // Octokit の PullRequestReviewThreadEvent が持つ Review プロパティは
+        // 実際の GitHub ペイロードに存在しない "review" フィールドにマッピングされており常に null になる
+        // （実データは "thread" フィールドにある）。そのため AdditionalProperties から
+        // thread.node_id を直接読み取り、スレッド識別子として使用する
+        var threadNodeId = GetThreadNodeId();
         SimplePullRequest pr = Event.PullRequest;
         Repository repo = Event.Repository;
         User sender = Event.Sender;
@@ -46,7 +48,7 @@ public sealed class PullRequestReviewThreadAction(
 
         var fields = new List<DiscordEmbedField>
         {
-            new("Thread ID", review.NodeId, false),
+            new("Thread ID", threadNodeId, false),
             new("Resolved", resolved ? "Yes" : "No", true),
         };
 
@@ -69,7 +71,27 @@ public sealed class PullRequestReviewThreadAction(
             author: author,
             fields: fields);
 
-        var key = $"{repo.FullName}-pr-review-thread-{review.NodeId}";
+        var key = $"{repo.FullName}-pr-review-thread-{threadNodeId}";
         await SendMessageAsync(key, new DiscordMessage(Content: content, Embeds: [embed]));
+    }
+
+    /// <summary>
+    /// AdditionalProperties から "thread.node_id" を取得する。
+    /// 想定外のペイロード形状であっても例外にせず、警告ログを出力して代替値を返す
+    /// </summary>
+    private string GetThreadNodeId()
+    {
+        if (Event.AdditionalProperties is { } props
+            && props.TryGetValue("thread", out JsonElement thread)
+            && thread.ValueKind == JsonValueKind.Object
+            && thread.TryGetProperty("node_id", out JsonElement nodeId)
+            && nodeId.ValueKind == JsonValueKind.String
+            && nodeId.GetString() is { Length: > 0 } value)
+        {
+            return value;
+        }
+
+        Logger.LogWarning("pull_request_review_thread payload is missing thread.node_id; falling back to \"unknown\".");
+        return "unknown";
     }
 }

--- a/src/Actions/Impl/PullRequestReviewThreadAction.cs
+++ b/src/Actions/Impl/PullRequestReviewThreadAction.cs
@@ -26,10 +26,8 @@ public sealed class PullRequestReviewThreadAction(
     /// <inheritdoc/>
     public override async Task RunAsync()
     {
-        // Octokit の PullRequestReviewThreadEvent が持つ Review プロパティは
-        // 実際の GitHub ペイロードに存在しない "review" フィールドにマッピングされており常に null になる
-        // （実データは "thread" フィールドにある）。そのため AdditionalProperties から
-        // thread.node_id を直接読み取り、スレッド識別子として使用する
+        // Event.Review は実ペイロードに存在しない "review" フィールドにマッピングされ常に null になるため、
+        // 実データを持つ AdditionalProperties["thread"].node_id をスレッド識別子として使用する
         var threadNodeId = GetThreadNodeId();
         SimplePullRequest pr = Event.PullRequest;
         Repository repo = Event.Repository;
@@ -71,7 +69,8 @@ public sealed class PullRequestReviewThreadAction(
             author: author,
             fields: fields);
 
-        var key = $"{repo.FullName}-pr-review-thread-{threadNodeId}";
+        // PR 番号を含め、threadNodeId が "unknown" にフォールバックした際のキー衝突を防ぐ
+        var key = $"{repo.FullName}-pr-review-thread-{pr.Number}-{threadNodeId}";
         await SendMessageAsync(key, new DiscordMessage(Content: content, Embeds: [embed]));
     }
 

--- a/src/GitHubWebhookBridge.csproj
+++ b/src/GitHubWebhookBridge.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
     <!-- Utilities -->
     <PackageReference Include="DiffPlex" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
     <PackageReference Include="Octokit.Webhooks" Version="4.0.4" />
     <!-- StyleCop: ビルド時のみ使用（出力には含まれない） -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -2,6 +2,7 @@ using Azure.Monitor.OpenTelemetry.Exporter;
 using GitHubWebhookBridge.Actions;
 using GitHubWebhookBridge.Managers;
 using GitHubWebhookBridge.Services;
+using GitHubWebhookBridge.Utils;
 using Microsoft.Azure.Functions.Worker.OpenTelemetry;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -39,7 +40,9 @@ hostBuilder.ConfigureServices(services =>
         .AddHttpClient("config", c => c.Timeout = TimeSpan.FromSeconds(10))
         .Services
         // Discord Webhook 用クライアント（15 秒タイムアウト）
+        // 再試行ポリシーの内容は DiscordRetryPolicy を参照（単体テストとも共有）
         .AddHttpClient("discord", c => c.Timeout = TimeSpan.FromSeconds(15))
+        .AddResilienceHandler(DiscordRetryPolicy.HandlerName, DiscordRetryPolicy.Configure)
         .Services
         // Discord クライアント
         .AddSingleton<IDiscordClient, DiscordClient>()

--- a/src/Services/DiscordClient.cs
+++ b/src/Services/DiscordClient.cs
@@ -3,7 +3,12 @@ using GitHubWebhookBridge.Models.Discord;
 
 namespace GitHubWebhookBridge.Services;
 
-/// <summary>Discord Webhook API クライアントを実装するクラス</summary>
+/// <summary>
+/// Discord Webhook API クライアントを実装するクラス。
+/// 429 (レート制限) に対する再試行は "discord" 名前付き HttpClient に構成した
+/// Microsoft.Extensions.Http.Resilience のリトライハンドラーが担う
+/// （<see cref="Program"/>、<see cref="Utils.DiscordRetryPolicy"/> 参照）
+/// </summary>
 public class DiscordClient(IHttpClientFactory httpClientFactory) : IDiscordClient
 {
     private readonly IHttpClientFactory _httpClientFactory = httpClientFactory;

--- a/src/Utils/DiscordRetryPolicy.cs
+++ b/src/Utils/DiscordRetryPolicy.cs
@@ -39,11 +39,8 @@ public static class DiscordRetryPolicy
             Delay = Delay,
             MaxDelay = MaxDelay,
             UseJitter = true,
-            // ShouldRetryAfterHeader = true（既定値）が内部で設定する DelayGenerator は
-            // Retry-After ヘッダーの値をそのまま採用し、MaxDelay で頭打ちにしない
-            // （Microsoft.Extensions.Http.Resilience 10.7.0 で確認済みの挙動）。
-            // 「長すぎるリトライを避ける」要件を満たすため、ここでは無効化し、
-            // 下記の DelayGenerator で Retry-After を解釈しつつ MaxDelay に丸める
+            // 既定の ShouldRetryAfterHeader = true は Retry-After の値をそのまま採用し MaxDelay で
+            // 頭打ちにしないため（v10.7.0 で確認済み）、無効化し下記 DelayGenerator で丸める
             ShouldRetryAfterHeader = false,
             DelayGenerator = args =>
             {

--- a/src/Utils/DiscordRetryPolicy.cs
+++ b/src/Utils/DiscordRetryPolicy.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Microsoft.Extensions.Http.Resilience;
+using Polly;
+
+namespace GitHubWebhookBridge.Utils;
+
+/// <summary>
+/// "discord" 名前付き HttpClient に適用する再試行ポリシーを定義する。
+/// 対象は 429 (レート制限) のみとし、Retry-After ヘッダーを尊重しつつ短い上限で打ち切ることで、
+/// Discord 側の障害・輻輳時に Webhook 処理全体が長時間ブロックされるのを防ぐ。
+/// <see cref="Program"/> と単体テストの両方から参照し、実装を一箇所に集約する
+/// </summary>
+public static class DiscordRetryPolicy
+{
+    /// <summary>AddResilienceHandler に渡すハンドラー名。</summary>
+    public const string HandlerName = "discord-retry";
+
+    /// <summary>再試行の最大回数（初回試行を含まない）。</summary>
+    public const int MaxRetryAttempts = 2;
+
+    /// <summary>Retry-After ヘッダーが無い場合の基準待機時間。</summary>
+    public static readonly TimeSpan Delay = TimeSpan.FromMilliseconds(500);
+
+    /// <summary>Retry-After ヘッダーの指定値を含め、待機時間の上限とする値。</summary>
+    public static readonly TimeSpan MaxDelay = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// <see cref="ResiliencePipelineBuilder{HttpResponseMessage}"/> に再試行戦略を追加する
+    /// </summary>
+    public static void Configure(ResiliencePipelineBuilder<HttpResponseMessage> builder)
+    {
+        HttpRetryStrategyOptions options = new()
+        {
+            ShouldHandle = args => ValueTask.FromResult(
+                args.Outcome.Result?.StatusCode == HttpStatusCode.TooManyRequests),
+            MaxRetryAttempts = MaxRetryAttempts,
+            BackoffType = DelayBackoffType.Constant,
+            Delay = Delay,
+            MaxDelay = MaxDelay,
+            UseJitter = true,
+            // ShouldRetryAfterHeader = true（既定値）が内部で設定する DelayGenerator は
+            // Retry-After ヘッダーの値をそのまま採用し、MaxDelay で頭打ちにしない
+            // （Microsoft.Extensions.Http.Resilience 10.7.0 で確認済みの挙動）。
+            // 「長すぎるリトライを避ける」要件を満たすため、ここでは無効化し、
+            // 下記の DelayGenerator で Retry-After を解釈しつつ MaxDelay に丸める
+            ShouldRetryAfterHeader = false,
+            DelayGenerator = args =>
+            {
+                RetryConditionHeaderValue? retryAfter = args.Outcome.Result?.Headers.RetryAfter;
+                TimeSpan? delay = retryAfter switch
+                {
+                    { Delta: { } d } => d,
+                    { Date: { } date } => date - DateTimeOffset.UtcNow,
+                    _ => null,
+                };
+                return ValueTask.FromResult(delay is { } d2 && d2 > TimeSpan.Zero
+                    ? (TimeSpan?)(d2 > MaxDelay ? MaxDelay : d2)
+                    : null);
+            },
+        };
+
+        builder.AddRetry(options);
+    }
+}

--- a/tests/DiscordRetryPolicyTests.cs
+++ b/tests/DiscordRetryPolicyTests.cs
@@ -1,0 +1,121 @@
+using System.Diagnostics;
+using System.Net;
+using GitHubWebhookBridge.Utils;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GitHubWebhookBridge.Tests;
+
+/// <summary>
+/// DiscordRetryPolicy が "discord" 名前付き HttpClient に構成する再試行挙動のテスト。
+/// Program.cs と同一の登録方法（AddHttpClient + AddResilienceHandler）を
+/// 最小構成の ServiceCollection で再現し、実際の HTTP パイプラインを通して検証する
+/// （ポリシーの中身だけを単体で呼び出すテストでは、DI 登録の配線ミスを検出できないため）
+/// </summary>
+public class DiscordRetryPolicyTests
+{
+    private static IHttpClientFactory BuildFactory(HttpMessageHandler handler)
+    {
+        ServiceCollection services = new();
+        services
+            .AddHttpClient("discord")
+            .ConfigurePrimaryHttpMessageHandler(() => handler)
+            .AddResilienceHandler(DiscordRetryPolicy.HandlerName, DiscordRetryPolicy.Configure);
+        return services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>();
+    }
+
+    private static HttpResponseMessage TooManyRequests(TimeSpan? retryAfter = null)
+    {
+        HttpResponseMessage response = new(HttpStatusCode.TooManyRequests);
+        if (retryAfter is { } d)
+        {
+            response.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(d);
+        }
+
+        return response;
+    }
+
+    /// <summary>429 が 1 回だけ発生した場合、再試行の末に成功する。</summary>
+    [Fact]
+    public async Task SendAsyncRetriesOnceAndSucceedsAfterSingleTooManyRequests()
+    {
+        QueueHttpMessageHandler handler = new(
+            _ => TooManyRequests(TimeSpan.FromMilliseconds(10)),
+            _ => new HttpResponseMessage(HttpStatusCode.OK));
+        HttpClient client = BuildFactory(handler).CreateClient("discord");
+
+        HttpResponseMessage response = await client.GetAsync(new Uri("https://discord.test/webhook"));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(2, handler.CallCount);
+    }
+
+    /// <summary>429 が続く場合でも、最大試行回数（初回 + 2 回）で打ち切られる。</summary>
+    [Fact]
+    public async Task SendAsyncStopsAfterMaxRetryAttemptsWhenAlwaysTooManyRequests()
+    {
+        QueueHttpMessageHandler handler = new(_ => TooManyRequests(TimeSpan.FromMilliseconds(10)));
+        HttpClient client = BuildFactory(handler).CreateClient("discord");
+
+        HttpResponseMessage response = await client.GetAsync(new Uri("https://discord.test/webhook"));
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, response.StatusCode);
+        Assert.Equal(1 + DiscordRetryPolicy.MaxRetryAttempts, handler.CallCount);
+    }
+
+    /// <summary>429 以外（5xx 等）は再試行の対象外で、即座に応答が返る。</summary>
+    [Fact]
+    public async Task SendAsyncDoesNotRetryOnServerError()
+    {
+        QueueHttpMessageHandler handler = new(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+        HttpClient client = BuildFactory(handler).CreateClient("discord");
+
+        HttpResponseMessage response = await client.GetAsync(new Uri("https://discord.test/webhook"));
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.Equal(1, handler.CallCount);
+    }
+
+    /// <summary>
+    /// Retry-After ヘッダーが無い 429 応答でも、DelayGenerator が null を返して
+    /// 既定の Delay/MaxDelay に基づく再試行にフォールバックし、再試行の末に成功することを確認する
+    /// （このパスはこれまでテストが無く、既定バックオフの配線ミスを検出できなかったための追加）。
+    /// </summary>
+    [Fact]
+    public async Task SendAsyncRetriesUsingDefaultDelayWhenRetryAfterHeaderIsAbsent()
+    {
+        QueueHttpMessageHandler handler = new(
+            _ => TooManyRequests(),
+            _ => new HttpResponseMessage(HttpStatusCode.OK));
+        HttpClient client = BuildFactory(handler).CreateClient("discord");
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        HttpResponseMessage response = await client.GetAsync(new Uri("https://discord.test/webhook"));
+        stopwatch.Stop();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(2, handler.CallCount);
+        // 既定の Delay（500ms）+ ジッター程度に収まるはずで、MaxDelay（2 秒）を大きく超えない
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5), $"Retry wait too long: {stopwatch.Elapsed}");
+    }
+
+    /// <summary>
+    /// Retry-After ヘッダーが極端に長い値を指定してきても、MaxDelay で頭打ちになり、
+    /// 全体の待機時間が長すぎるリトライにならないことを確認する
+    /// </summary>
+    [Fact]
+    public async Task SendAsyncCapsWaitTimeEvenWhenRetryAfterHeaderIsVeryLong()
+    {
+        QueueHttpMessageHandler handler = new(
+            _ => TooManyRequests(TimeSpan.FromMinutes(10)),
+            _ => new HttpResponseMessage(HttpStatusCode.OK));
+        HttpClient client = BuildFactory(handler).CreateClient("discord");
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        HttpResponseMessage response = await client.GetAsync(new Uri("https://discord.test/webhook"));
+        stopwatch.Stop();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        // MaxDelay (2 秒) + ジッター程度に収まるはずで、Retry-After が示す 10 分は待たない
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5), $"Retry wait too long: {stopwatch.Elapsed}");
+    }
+}

--- a/tests/DiscordRetryPolicyTests.cs
+++ b/tests/DiscordRetryPolicyTests.cs
@@ -94,8 +94,8 @@ public class DiscordRetryPolicyTests
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal(2, handler.CallCount);
-        // 既定の Delay（500ms）+ ジッター程度に収まるはずで、MaxDelay（2 秒）を大きく超えない
-        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5), $"Retry wait too long: {stopwatch.Elapsed}");
+        // 既定の Delay（500ms）+ ジッター程度に収まるはずだが、CI のフレーク耐性のため閾値には余裕を持たせる
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(15), $"Retry wait too long: {stopwatch.Elapsed}");
     }
 
     /// <summary>
@@ -115,7 +115,7 @@ public class DiscordRetryPolicyTests
         stopwatch.Stop();
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        // MaxDelay (2 秒) + ジッター程度に収まるはずで、Retry-After が示す 10 分は待たない
-        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5), $"Retry wait too long: {stopwatch.Elapsed}");
+        // MaxDelay（2 秒）に収まるはずで Retry-After の 10 分は待たないが、CI のフレーク耐性のため閾値には余裕を持たせる
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(15), $"Retry wait too long: {stopwatch.Elapsed}");
     }
 }

--- a/tests/FakeHttp.cs
+++ b/tests/FakeHttp.cs
@@ -57,9 +57,21 @@ internal sealed class FakeHttpResponseData(FunctionContext functionContext) : Ht
 /// リトライハンドラーが実際に何回リクエストを送出したかを検証するために使用する。
 /// 用意した応答を使い切った場合は最後の応答を返し続ける
 /// </summary>
-internal sealed class QueueHttpMessageHandler(params Func<HttpRequestMessage, HttpResponseMessage>[] responders) : HttpMessageHandler
+internal sealed class QueueHttpMessageHandler : HttpMessageHandler
 {
+    private readonly Func<HttpRequestMessage, HttpResponseMessage>[] _responders;
     private int _callCount;
+
+    public QueueHttpMessageHandler(params Func<HttpRequestMessage, HttpResponseMessage>[] responders)
+    {
+        ArgumentNullException.ThrowIfNull(responders);
+        if (responders.Length == 0)
+        {
+            throw new ArgumentException("At least one responder must be provided.", nameof(responders));
+        }
+
+        _responders = responders;
+    }
 
     /// <summary>実際に送出されたリクエストの回数。</summary>
     public int CallCount => _callCount;
@@ -67,7 +79,7 @@ internal sealed class QueueHttpMessageHandler(params Func<HttpRequestMessage, Ht
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         int index = Interlocked.Increment(ref _callCount) - 1;
-        Func<HttpRequestMessage, HttpResponseMessage> responder = responders[Math.Min(index, responders.Length - 1)];
+        Func<HttpRequestMessage, HttpResponseMessage> responder = _responders[Math.Min(index, _responders.Length - 1)];
         return Task.FromResult(responder(request));
     }
 }

--- a/tests/FakeHttp.cs
+++ b/tests/FakeHttp.cs
@@ -51,3 +51,23 @@ internal sealed class FakeHttpResponseData(FunctionContext functionContext) : Ht
     public override Stream Body { get; set; } = new MemoryStream();
     public override HttpCookies Cookies { get; } = null!;
 }
+
+/// <summary>
+/// あらかじめ用意した応答を順番に返す <see cref="HttpMessageHandler"/>。
+/// リトライハンドラーが実際に何回リクエストを送出したかを検証するために使用する。
+/// 用意した応答を使い切った場合は最後の応答を返し続ける
+/// </summary>
+internal sealed class QueueHttpMessageHandler(params Func<HttpRequestMessage, HttpResponseMessage>[] responders) : HttpMessageHandler
+{
+    private int _callCount;
+
+    /// <summary>実際に送出されたリクエストの回数。</summary>
+    public int CallCount => _callCount;
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        int index = Interlocked.Increment(ref _callCount) - 1;
+        Func<HttpRequestMessage, HttpResponseMessage> responder = responders[Math.Min(index, responders.Length - 1)];
+        return Task.FromResult(responder(request));
+    }
+}

--- a/tests/PullRequestReviewThreadActionTests.cs
+++ b/tests/PullRequestReviewThreadActionTests.cs
@@ -34,10 +34,7 @@ public class PullRequestReviewThreadActionTests
 
     /// <summary>
     /// PullRequestReviewThreadEvent を JSON から生成する。
-    /// 実際の GitHub ペイロードには "review" フィールドは存在せず、"thread"（node_id・comments）が
-    /// スレッドを表す。Octokit にはこれに対応する強い型プロパティが無いため、
-    /// 実装は Event.AdditionalProperties 経由で thread.node_id を読み取る。
-    /// このテストはその実装が読み取る実データの形状（"thread"）を忠実に再現する
+    /// 実際の GitHub ペイロードの形状（"review" ではなく "thread"）を忠実に再現する
     /// </summary>
     private static PullRequestReviewThreadEvent MakeEvent(string action) =>
         JsonSerializer.Deserialize<PullRequestReviewThreadEvent>(
@@ -152,7 +149,7 @@ public class PullRequestReviewThreadActionTests
 
         await action.RunAsync();
 
-        cache.Verify(c => c.GetAsync(_webhookUri, "test/repo-pr-review-thread-RT_node_abc"), Times.Once);
+        cache.Verify(c => c.GetAsync(_webhookUri, "test/repo-pr-review-thread-12-RT_node_abc"), Times.Once);
     }
 
     /// <summary>
@@ -196,10 +193,8 @@ public class PullRequestReviewThreadActionTests
     }
 
     /// <summary>
-    /// thread.node_id が文字列以外の JSON 値（数値等）である想定外のペイロードでも例外を投げず、
-    /// "unknown" にフォールバックして通知を送信する
-    /// （JsonElement.GetString() は String/Null 以外の ValueKind で例外を投げるため、
-    /// ValueKind を確認せずに呼び出すと再度 NullReferenceException 相当の障害に戻ってしまう再発防止テスト）。
+    /// thread.node_id が文字列以外の JSON 値（数値等）でも例外を投げず、
+    /// "unknown" にフォールバックして通知を送信する（GetString() の ValueKind 未検証による例外の再発防止）。
     /// </summary>
     [Fact]
     public async Task RunAsyncFallsBackToUnknownWhenThreadNodeIdIsNotAString()

--- a/tests/PullRequestReviewThreadActionTests.cs
+++ b/tests/PullRequestReviewThreadActionTests.cs
@@ -34,18 +34,17 @@ public class PullRequestReviewThreadActionTests
 
     /// <summary>
     /// PullRequestReviewThreadEvent を JSON から生成する。
-    /// Octokit の PullRequestReviewThreadEvent には Thread プロパティが存在しないため、
-    /// Review.NodeId をスレッド識別子として使用する。
+    /// 実際の GitHub ペイロードには "review" フィールドは存在せず、"thread"（node_id・comments）が
+    /// スレッドを表す。Octokit にはこれに対応する強い型プロパティが無いため、
+    /// 実装は Event.AdditionalProperties 経由で thread.node_id を読み取る。
+    /// このテストはその実装が読み取る実データの形状（"thread"）を忠実に再現する
     /// </summary>
     private static PullRequestReviewThreadEvent MakeEvent(string action) =>
         JsonSerializer.Deserialize<PullRequestReviewThreadEvent>(
             $$"""
             {
                 "action":"{{action}}",
-                "review":{{TestFixtures.ReviewJson(
-                    1, "approved",
-                    "https://github.com/test/repo/pull/12#pullrequestreview-1",
-                    nodeId: "RT_node_abc")}},
+                "thread":{{TestFixtures.ThreadJson(nodeId: "RT_node_abc")}},
                 "pull_request":{{TestFixtures.SimplePrJson(
                     12, "Feature branch",
                     "https://github.com/test/repo/pull/12",
@@ -154,6 +153,88 @@ public class PullRequestReviewThreadActionTests
         await action.RunAsync();
 
         cache.Verify(c => c.GetAsync(_webhookUri, "test/repo-pr-review-thread-RT_node_abc"), Times.Once);
+    }
+
+    /// <summary>
+    /// thread フィールドが存在しない想定外のペイロードでも例外を投げず、
+    /// "unknown" にフォールバックして通知を送信する
+    /// （Octokit の Review プロパティが常に null になる旧実装の再発防止テスト）。
+    /// </summary>
+    [Fact]
+    public async Task RunAsyncFallsBackToUnknownWhenThreadFieldIsMissing()
+    {
+        (Mock<IDiscordClient>? discord, Mock<IMessageCacheService>? cache, Mock<IGitHubUserMapManager>? userMap) = CreateMocks();
+
+        PullRequestReviewThreadEvent eventWithoutThread = JsonSerializer.Deserialize<PullRequestReviewThreadEvent>(
+            $$"""
+            {
+                "action":"resolved",
+                "pull_request":{{TestFixtures.SimplePrJson(
+                    12, "Feature branch",
+                    "https://github.com/test/repo/pull/12",
+                    "pr-author", 50)}},
+                "repository":{{TestFixtures.RepoJson("test/repo","https://github.com/test/repo")}},
+                "sender":{{TestFixtures.UserJson("reviewer",60)}}
+            }
+            """,
+            OctokitJsonOptions.Value)!;
+
+        PullRequestReviewThreadAction action = new(
+            discord.Object, cache.Object, userMap.Object,
+            Mock.Of<ILogger<PullRequestReviewThreadAction>>(),
+            _webhookUri, "pull_request_review_thread", eventWithoutThread);
+
+        await action.RunAsync();
+
+        discord.Verify(
+            d => d.SendMessageAsync(
+                It.IsAny<Uri>(),
+                It.Is<DiscordMessage>(m =>
+                    m.Embeds![0].Fields != null &&
+                    m.Embeds![0].Fields!.Any(f => f.Value.Contains("unknown")))),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// thread.node_id が文字列以外の JSON 値（数値等）である想定外のペイロードでも例外を投げず、
+    /// "unknown" にフォールバックして通知を送信する
+    /// （JsonElement.GetString() は String/Null 以外の ValueKind で例外を投げるため、
+    /// ValueKind を確認せずに呼び出すと再度 NullReferenceException 相当の障害に戻ってしまう再発防止テスト）。
+    /// </summary>
+    [Fact]
+    public async Task RunAsyncFallsBackToUnknownWhenThreadNodeIdIsNotAString()
+    {
+        (Mock<IDiscordClient>? discord, Mock<IMessageCacheService>? cache, Mock<IGitHubUserMapManager>? userMap) = CreateMocks();
+
+        PullRequestReviewThreadEvent eventWithNonStringNodeId = JsonSerializer.Deserialize<PullRequestReviewThreadEvent>(
+            $$"""
+            {
+                "action":"resolved",
+                "thread":{"node_id":12345,"comments":[{{TestFixtures.ReviewCommentJson()}}]},
+                "pull_request":{{TestFixtures.SimplePrJson(
+                    12, "Feature branch",
+                    "https://github.com/test/repo/pull/12",
+                    "pr-author", 50)}},
+                "repository":{{TestFixtures.RepoJson("test/repo","https://github.com/test/repo")}},
+                "sender":{{TestFixtures.UserJson("reviewer",60)}}
+            }
+            """,
+            OctokitJsonOptions.Value)!;
+
+        PullRequestReviewThreadAction action = new(
+            discord.Object, cache.Object, userMap.Object,
+            Mock.Of<ILogger<PullRequestReviewThreadAction>>(),
+            _webhookUri, "pull_request_review_thread", eventWithNonStringNodeId);
+
+        await action.RunAsync();
+
+        discord.Verify(
+            d => d.SendMessageAsync(
+                It.IsAny<Uri>(),
+                It.Is<DiscordMessage>(m =>
+                    m.Embeds![0].Fields != null &&
+                    m.Embeds![0].Fields!.Any(f => f.Value.Contains("unknown")))),
+            Times.Once);
     }
 
     /// <summary>PR 作成者が Discord にマッピングされている場合はメンション付きで送信する。</summary>

--- a/tests/TestFixtures.cs
+++ b/tests/TestFixtures.cs
@@ -122,6 +122,14 @@ internal static class TestFixtures
         return "{\"zen\":\"" + zen + "\",\"hook_id\":" + hookId + ",\"hook\":{\"type\":\"" + hookType + "\",\"id\":1,\"name\":\"web\",\"active\":true,\"events\":[\"push\"],\"config\":{\"content_type\":\"json\",\"url\":\"\",\"insecure_ssl\":\"0\"},\"url\":\"\",\"ping_url\":\"\",\"deliveries_url\":\"\",\"updated_at\":\"2024-01-01T00:00:00Z\",\"created_at\":\"2024-01-01T00:00:00Z\"}" + repoStr + senderStr + "}";
     }
 
+    /// <summary>
+    /// pull_request_review_thread イベントの Thread（node_id・comments）の最小 JSON。
+    /// Octokit には対応する強い型プロパティが無く、実装は AdditionalProperties 経由で読み取るため、
+    /// 実際の GitHub ペイロード（"review" ではなく "thread"）と同じ形状で用意する
+    /// </summary>
+    public static string ThreadJson(string nodeId = "PRRT_1", string? commentJson = null) =>
+        $$$"""{"node_id":"{{{nodeId}}}","comments":[{{{commentJson ?? ReviewCommentJson()}}}]}""";
+
     /// <summary>PullRequestReviewComment の最小 JSON。</summary>
     public static string ReviewCommentJson(long id = 1, string body = "Great!", string path = "src/file.cs", string? htmlUrl = null)
     {

--- a/tests/TestFixtures.cs
+++ b/tests/TestFixtures.cs
@@ -124,7 +124,6 @@ internal static class TestFixtures
 
     /// <summary>
     /// pull_request_review_thread イベントの Thread（node_id・comments）の最小 JSON。
-    /// Octokit には対応する強い型プロパティが無く、実装は AdditionalProperties 経由で読み取るため、
     /// 実際の GitHub ペイロード（"review" ではなく "thread"）と同じ形状で用意する
     /// </summary>
     public static string ThreadJson(string nodeId = "PRRT_1", string? commentJson = null) =>


### PR DESCRIPTION
## 概要

以下 2 件の修正を 1 つの PR にまとめています。

### 1. Discord 429 応答への有界リトライ

`Microsoft.Extensions.Http.Resilience`（v10.7.0）を導入し、Discord 送信用 `HttpClient`（名前付きクライアント `"discord"`）に 429 応答時のリトライを追加しました。

- 初回送信 + 最大 2 回まで再試行（`DiscordRetryPolicy.MaxRetryAttempts`）
- `Retry-After` ヘッダーの値を尊重しつつ、`MaxDelay`（2 秒）で頭打ちにする
  - ライブラリ標準の `ShouldRetryAfterHeader = true` はヘッダー由来の待機時間に `MaxDelay` のクランプが効かない既知の挙動のため、これを無効化し、カスタム `DelayGenerator` で明示的にクランプしています
- 429 以外（5xx 等）は再試行対象外

### 2. `PullRequestReviewThreadAction` の NullReferenceException 修正

Octokit.Webhooks の `PullRequestReviewThreadEvent.Review` プロパティが、実際の GitHub Webhook ペイロードには存在しない `"review"` フィールドにマッピングされており、常に `null` になっていました。これを参照していたため通知処理が `NullReferenceException` で落ちていました。

- 実データを持つ `"thread"` フィールドを `Event.AdditionalProperties` から直接読み取るように変更
- ペイロード形状が想定外（`thread` 欠落、`node_id` が非文字列など）でも例外を投げず `"unknown"` にフォールバックするようガード
- 実際のペイロード形状を再現したテストフィクスチャを整備し、上記フォールバック経路の回帰テストを追加

## テスト用網羅性の見直し（deep-review 対応）

deep-review 手順に従い、本 diff に対してバグ・セキュリティ・型設計/テストなど複数観点のレビューを実施し、スコア 50 以上の指摘を修正済みです。

- `GetThreadNodeId()` が `thread.node_id` が文字列以外の JSON 値だった場合に `JsonElement.GetString()` で `InvalidOperationException` を投げてしまう経路を修正し、回帰テストを追加
- `DiscordRetryPolicy` の `DelayGenerator` について、`Retry-After` ヘッダーが無い 429 応答時の既定バックオフ経路のテストが欠けていたため追加

### 既知のトレードオフ（今回は対応せず）

`BaseAction.SendMessageAsync` は直近 5 分以内に同じキーで送信済みの場合、新規送信ではなく既存メッセージの編集にフォールバックします。このフォールバック中に編集が失敗すると再送信が発生する既存の設計であり、今回追加したリトライと組み合わさると、429 が続いた場合に編集→再送信のパスで待ち時間が積み重なる可能性があります。この点は `BaseAction.cs` 自体を変更しない本 PR のスコープ外と判断し、既知の許容トレードオフとして記録するに留めています。

## テスト

- `dotnet build -c Release`: 0 errors
- `dotnet test -c Release`: 137/137 passed

