### PR TITLE
fix: Warningの修正とコメントの整理

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1198,3 +1198,5 @@ dotnet_diagnostic.CA1707.severity = none
 dotnet_diagnostic.IDE1006.severity = none
 # HMAC-SHA256 の hex 文字列は仕様上小文字のため ToLowerInvariant の使用を許容する
 dotnet_diagnostic.CA1308.severity = none
+# JsonSerializer.Deserialize<T> によるリフレクション経由のインスタンス化はアナライザーで検出できないため許容する
+dotnet_diagnostic.CA1812.severity = none

--- a/src/Actions/ActionFactory.cs
+++ b/src/Actions/ActionFactory.cs
@@ -17,13 +17,13 @@ public class ActionFactory(IServiceProvider sp) : IActionFactory
     private readonly FrozenDictionary<string, (Type Action, Type Payload)> _registry =
         BuildRegistry();
 
-    private static FrozenDictionary<string, (Type, Type)> BuildRegistry()
+    private static FrozenDictionary<string, (Type Action, Type Payload)> BuildRegistry()
     {
-        var entries = typeof(ActionFactory).Assembly.GetTypes()
+        IEnumerable<KeyValuePair<string, (Type Action, Type Payload)>> entries = typeof(ActionFactory).Assembly.GetTypes()
             .Where(t => t.GetCustomAttribute<GitHubEventAttribute>() != null && !t.IsAbstract)
             .Select(t =>
             {
-                var payloadType = GetPayloadType(t);
+                Type payloadType = GetPayloadType(t);
                 var eventName = ResolveEventName(t, payloadType);
                 return KeyValuePair.Create(eventName, (t, payloadType));
             });
@@ -34,18 +34,22 @@ public class ActionFactory(IServiceProvider sp) : IActionFactory
 
     private static Type GetPayloadType(Type actionType)
     {
-        var b = actionType.BaseType;
+        Type? b = actionType.BaseType;
         while (b != null && !(b.IsGenericType && b.GetGenericTypeDefinition() == typeof(BaseAction<>)))
             b = b.BaseType;
+
         if (b == null)
+        {
             throw new InvalidOperationException(
                 $"{actionType.Name} must inherit from BaseAction<T> to be registered via [GitHubEvent].");
+        }
+
         return b.GetGenericArguments()[0];
     }
 
     private static string ResolveEventName(Type actionType, Type payloadType)
     {
-        var attr = actionType.GetCustomAttribute<GitHubEventAttribute>()!;
+        GitHubEventAttribute attr = actionType.GetCustomAttribute<GitHubEventAttribute>()!;
         if (attr.EventName != null)
             return attr.EventName;
 
@@ -57,7 +61,7 @@ public class ActionFactory(IServiceProvider sp) : IActionFactory
     /// <inheritdoc/>
     public IAction GetAction(string eventName, string rawJson, Uri webhookUrl)
     {
-        if (!_registry.TryGetValue(eventName, out var entry))
+        if (!_registry.TryGetValue(eventName, out (Type Action, Type Payload) entry))
             return new UnhandledAction(eventName);
 
         var payload = JsonSerializer.Deserialize(rawJson, entry.Payload, OctokitJsonOptions.Value)

--- a/src/Actions/BaseAction.cs
+++ b/src/Actions/BaseAction.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 using DiffPlex.DiffBuilder;
 using DiffPlex.DiffBuilder.Model;
@@ -112,8 +113,8 @@ public abstract class BaseAction<TEvent>(
     {
         DiffPaneModel diff = InlineDiffBuilder.Diff(oldText, newText);
         var sb = new StringBuilder();
-        sb.AppendLine(System.Globalization.CultureInfo.InvariantCulture, $"--- {fileName}");
-        sb.AppendLine(System.Globalization.CultureInfo.InvariantCulture, $"+++ {fileName}");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"--- {fileName}");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"+++ {fileName}");
 
         foreach (DiffPiece? line in diff.Lines)
         {
@@ -126,7 +127,7 @@ public abstract class BaseAction<TEvent>(
                 ChangeType.Modified => throw new NotImplementedException(),
                 _ => " ",
             };
-            sb.AppendLine(System.Globalization.CultureInfo.InvariantCulture, $"{prefix} {line.Text}");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"{prefix} {line.Text}");
         }
 
         return sb.ToString();

--- a/src/Actions/GitHubEventAttribute.cs
+++ b/src/Actions/GitHubEventAttribute.cs
@@ -6,17 +6,12 @@ namespace GitHubWebhookBridge.Actions;
 /// 使用例: <c>[GitHubEvent(WebhookEventType.PullRequest)]</c>
 /// </para>
 /// </summary>
+/// <param name="eventName">GitHub Webhook イベント名（小文字スネークケース）</param>
 [AttributeUsage(AttributeTargets.Class, Inherited = false)]
-public sealed class GitHubEventAttribute : Attribute
+public sealed class GitHubEventAttribute(string eventName) : Attribute
 {
-    /// <summary>
-    /// イベント名を明示指定するコンストラクター
-    /// </summary>
-    /// <param name="eventName">GitHub Webhook イベント名（小文字スネークケース）</param>
-    public GitHubEventAttribute(string eventName) => EventName = eventName;
-
     /// <summary>
     /// <c>[GitHubEvent]</c> 属性で指定されたイベント名を取得する
     /// </summary>
-    public string EventName { get; }
+    public string EventName { get; } = eventName;
 }

--- a/src/Actions/Impl/DiscussionAction.cs
+++ b/src/Actions/Impl/DiscussionAction.cs
@@ -27,8 +27,12 @@ public sealed class DiscussionAction(
     public override async Task RunAsync()
     {
         Discussion discussion = Event.Discussion;
-        Repository repo = Event.Repository;
-        User sender = Event.Sender;
+
+        if (Event.Repository is not { } repo || Event.Sender is not { } sender)
+        {
+            Logger.LogWarning("discussion payload is missing repository or sender; skipping notification.");
+            return;
+        }
 
         (var titleVerb, var color) = Event.Action switch
         {
@@ -86,15 +90,15 @@ public sealed class DiscussionAction(
 
         var author = new DiscordEmbedAuthor(
             Name: sender.Login,
-            Url: Uri.TryCreate(sender.HtmlUrl, UriKind.Absolute, out var senderUrl) ? senderUrl : null,
-            IconUrl: Uri.TryCreate(sender.AvatarUrl, UriKind.Absolute, out var avatarUrl) ? avatarUrl : null);
+            Url: Uri.TryCreate(sender.HtmlUrl, UriKind.Absolute, out Uri? senderUrl) ? senderUrl : null,
+            IconUrl: Uri.TryCreate(sender.AvatarUrl, UriKind.Absolute, out Uri? avatarUrl) ? avatarUrl : null);
 
         DiscordEmbed embed = EmbedHelper.CreateEmbed(
             eventName: EventName,
             color: color,
             title: title,
             description: description,
-            url: Uri.TryCreate(discussion.HtmlUrl, UriKind.Absolute, out var discussionUrl) ? discussionUrl : null,
+            url: Uri.TryCreate(discussion.HtmlUrl, UriKind.Absolute, out Uri? discussionUrl) ? discussionUrl : null,
             author: author,
             fields: fields);
 

--- a/src/Actions/Impl/ForkAction.cs
+++ b/src/Actions/Impl/ForkAction.cs
@@ -24,19 +24,25 @@ public sealed class ForkAction(
     /// <inheritdoc/>
     public override async Task RunAsync()
     {
+        if (Event.Sender is not { } sender || Event.Repository is not { } repo)
+        {
+            Logger.LogWarning("fork payload is missing sender or repository; skipping notification.");
+            return;
+        }
+
         var author = new DiscordEmbedAuthor(
-            Name: Event.Sender.Login,
-            Url: Uri.TryCreate(Event.Sender.HtmlUrl, UriKind.Absolute, out var senderUrl) ? senderUrl : null,
-            IconUrl: Uri.TryCreate(Event.Sender.AvatarUrl, UriKind.Absolute, out var avatarUrl) ? avatarUrl : null);
+            Name: sender.Login,
+            Url: Uri.TryCreate(sender.HtmlUrl, UriKind.Absolute, out Uri? senderUrl) ? senderUrl : null,
+            IconUrl: Uri.TryCreate(sender.AvatarUrl, UriKind.Absolute, out Uri? avatarUrl) ? avatarUrl : null);
 
         DiscordEmbed embed = EmbedHelper.CreateEmbed(
             eventName: EventName,
             color: EmbedColors.Fork,
-            title: $"Forked {Event.Repository.FullName} by {Event.Sender.Login} to {Event.Forkee.FullName}",
-            url: Uri.TryCreate(Event.Forkee.HtmlUrl, UriKind.Absolute, out var forkeeUrl) ? forkeeUrl : null,
+            title: $"Forked {repo.FullName} by {sender.Login} to {Event.Forkee.FullName}",
+            url: Uri.TryCreate(Event.Forkee.HtmlUrl, UriKind.Absolute, out Uri? forkeeUrl) ? forkeeUrl : null,
             author: author);
 
-        var key = $"{Event.Repository.FullName}-fork-{Event.Sender.Login}";
+        var key = $"{repo.FullName}-fork-{sender.Login}";
         await SendMessageAsync(key, new DiscordMessage(Embeds: [embed]));
     }
 }

--- a/src/Actions/Impl/IssueCommentAction.cs
+++ b/src/Actions/Impl/IssueCommentAction.cs
@@ -27,8 +27,12 @@ public sealed class IssueCommentAction(
     {
         Issue issue = Event.Issue;
         IssueComment comment = Event.Comment;
-        Repository repo = Event.Repository;
-        User sender = Event.Sender;
+
+        if (Event.Repository is not { } repo || Event.Sender is not { } sender)
+        {
+            Logger.LogWarning("issue_comment payload is missing repository or sender; skipping notification.");
+            return;
+        }
 
         // Issue に関連するのが PR かどうかで種別を変える（IssuePullRequest.HtmlUrl が空でなければ PR）
         var issueType = !string.IsNullOrEmpty(issue.PullRequest?.HtmlUrl) ? "PR" : "Issue";
@@ -56,15 +60,15 @@ public sealed class IssueCommentAction(
 
         var author = new DiscordEmbedAuthor(
             Name: sender.Login,
-            Url: Uri.TryCreate(sender.HtmlUrl, UriKind.Absolute, out var senderUrl) ? senderUrl : null,
-            IconUrl: Uri.TryCreate(sender.AvatarUrl, UriKind.Absolute, out var avatarUrl) ? avatarUrl : null);
+            Url: Uri.TryCreate(sender.HtmlUrl, UriKind.Absolute, out Uri? senderUrl) ? senderUrl : null,
+            IconUrl: Uri.TryCreate(sender.AvatarUrl, UriKind.Absolute, out Uri? avatarUrl) ? avatarUrl : null);
 
         DiscordEmbed embed = EmbedHelper.CreateEmbed(
             eventName: EventName,
             color: color,
             title: title,
             description: body,
-            url: Uri.TryCreate(comment.HtmlUrl, UriKind.Absolute, out var commentUrl) ? commentUrl : null,
+            url: Uri.TryCreate(comment.HtmlUrl, UriKind.Absolute, out Uri? commentUrl) ? commentUrl : null,
             author: author);
 
         var key = $"{repo.FullName}-issue-comment-{comment.Id.ToString(System.Globalization.CultureInfo.InvariantCulture)}";

--- a/src/Actions/Impl/IssueCommentAction.cs
+++ b/src/Actions/Impl/IssueCommentAction.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using GitHubWebhookBridge.Managers;
 using GitHubWebhookBridge.Models.Discord;
 using GitHubWebhookBridge.Services;
@@ -71,7 +72,7 @@ public sealed class IssueCommentAction(
             url: Uri.TryCreate(comment.HtmlUrl, UriKind.Absolute, out Uri? commentUrl) ? commentUrl : null,
             author: author);
 
-        var key = $"{repo.FullName}-issue-comment-{comment.Id.ToString(System.Globalization.CultureInfo.InvariantCulture)}";
+        var key = $"{repo.FullName}-issue-comment-{comment.Id.ToString(CultureInfo.InvariantCulture)}";
         await SendMessageAsync(key, new DiscordMessage(Content: content, Embeds: [embed]));
     }
 }

--- a/src/Actions/Impl/IssuesAction.cs
+++ b/src/Actions/Impl/IssuesAction.cs
@@ -34,7 +34,8 @@ public sealed class IssuesAction(
             return;
         }
 
-        var action = Event.Action ?? string.Empty;
+        // 通知タイトルとキャッシュキーの一意性を保つため、欠損時は空文字ではなく明示的な既定値を使う
+        var action = Event.Action ?? "unknown";
         (var title, var color) = GetTitleAndColor(action, issue);
 
         // サブタイプ固有プロパティをパターンマッチで取得する

--- a/src/Actions/Impl/IssuesAction.cs
+++ b/src/Actions/Impl/IssuesAction.cs
@@ -27,29 +27,15 @@ public sealed class IssuesAction(
     public override async Task RunAsync()
     {
         Issue issue = Event.Issue;
-        Repository repo = Event.Repository;
-        User sender = Event.Sender;
 
-        (var title, var color) = Event.Action switch
+        if (Event.Repository is not { } repo || Event.Sender is not { } sender)
         {
-            "opened" => ($"Issue opened: #{issue.Number} {issue.Title}", EmbedColors.IssueOpened),
-            "closed" => ($"Issue closed: #{issue.Number} {issue.Title}", EmbedColors.IssueClosed),
-            "reopened" => ($"Issue reopened: #{issue.Number} {issue.Title}", EmbedColors.IssueReopened),
-            "edited" => ($"Issue edited: #{issue.Number} {issue.Title}", EmbedColors.IssueEdited),
-            "labeled" => ($"Issue labeled: #{issue.Number} {issue.Title}", EmbedColors.IssueLabeled),
-            "unlabeled" => ($"Issue unlabeled: #{issue.Number} {issue.Title}", EmbedColors.IssueUnlabeled),
-            "assigned" => ($"Issue assigned: #{issue.Number} {issue.Title}", EmbedColors.IssueAssigned),
-            "unassigned" => ($"Issue unassigned: #{issue.Number} {issue.Title}", EmbedColors.IssueUnassigned),
-            "milestoned" => ($"Issue milestoned: #{issue.Number} {issue.Title}", EmbedColors.IssueMilestoned),
-            "demilestoned" => ($"Issue demilestoned: #{issue.Number} {issue.Title}", EmbedColors.IssueDemilestoned),
-            "locked" => ($"Issue locked: #{issue.Number} {issue.Title}", EmbedColors.IssueLocked),
-            "unlocked" => ($"Issue unlocked: #{issue.Number} {issue.Title}", EmbedColors.IssueUnlocked),
-            "transferred" => ($"Issue transferred: #{issue.Number} {issue.Title}", EmbedColors.IssueTransferred),
-            "pinned" => ($"Issue pinned: #{issue.Number} {issue.Title}", EmbedColors.IssuePinned),
-            "unpinned" => ($"Issue unpinned: #{issue.Number} {issue.Title}", EmbedColors.IssueUnpinned),
-            "deleted" => ($"Issue deleted: #{issue.Number} {issue.Title}", EmbedColors.IssueDeleted),
-            _ => ($"Issue {Event.Action}: #{issue.Number} {issue.Title}", EmbedColors.Unknown),
-        };
+            Logger.LogWarning("issues payload is missing repository or sender; skipping notification.");
+            return;
+        }
+
+        var action = Event.Action ?? string.Empty;
+        (var title, var color) = GetTitleAndColor(action, issue);
 
         // サブタイプ固有プロパティをパターンマッチで取得する
         Label? label = (Event as IssuesLabeledEvent)?.Label
@@ -60,10 +46,63 @@ public sealed class IssuesAction(
                                ?? (Event as IssuesDemilestonedEvent)?.Milestone;
         Octokit.Webhooks.Models.IssuesEvent.Changes? changes = (Event as IssuesEditedEvent)?.Changes;
 
+        List<DiscordEmbedField> fields = BuildFields(repo, issue, label, assignee, milestone);
+        var description = BuildDescription(action, issue, changes);
+
+        var author = new DiscordEmbedAuthor(
+            Name: sender.Login,
+            Url: Uri.TryCreate(sender.HtmlUrl, UriKind.Absolute, out Uri? senderUrl) ? senderUrl : null,
+            IconUrl: Uri.TryCreate(sender.AvatarUrl, UriKind.Absolute, out Uri? avatarUrl) ? avatarUrl : null);
+
+        DiscordEmbed embed = EmbedHelper.CreateEmbed(
+            eventName: EventName,
+            color: color,
+            title: title,
+            description: description,
+            url: Uri.TryCreate(issue.HtmlUrl, UriKind.Absolute, out Uri? issueUrl) ? issueUrl : null,
+            author: author,
+            fields: fields);
+
+        // アクション別キー（同一性質のペアは共通キーで編集対象を統一）
+        var keySuffix = GetKeySuffix(action);
+        var key = $"{repo.FullName}#{issue.Number}-{keySuffix}";
+        await SendMessageAsync(key, new DiscordMessage(Embeds: [embed]));
+    }
+
+    /// <summary>action ごとの埋め込みタイトルと色を決定する</summary>
+    private static (string Title, int Color) GetTitleAndColor(string action, Issue issue) => action switch
+    {
+        "opened" => ($"Issue opened: #{issue.Number} {issue.Title}", EmbedColors.IssueOpened),
+        "closed" => ($"Issue closed: #{issue.Number} {issue.Title}", EmbedColors.IssueClosed),
+        "reopened" => ($"Issue reopened: #{issue.Number} {issue.Title}", EmbedColors.IssueReopened),
+        "edited" => ($"Issue edited: #{issue.Number} {issue.Title}", EmbedColors.IssueEdited),
+        "labeled" => ($"Issue labeled: #{issue.Number} {issue.Title}", EmbedColors.IssueLabeled),
+        "unlabeled" => ($"Issue unlabeled: #{issue.Number} {issue.Title}", EmbedColors.IssueUnlabeled),
+        "assigned" => ($"Issue assigned: #{issue.Number} {issue.Title}", EmbedColors.IssueAssigned),
+        "unassigned" => ($"Issue unassigned: #{issue.Number} {issue.Title}", EmbedColors.IssueUnassigned),
+        "milestoned" => ($"Issue milestoned: #{issue.Number} {issue.Title}", EmbedColors.IssueMilestoned),
+        "demilestoned" => ($"Issue demilestoned: #{issue.Number} {issue.Title}", EmbedColors.IssueDemilestoned),
+        "locked" => ($"Issue locked: #{issue.Number} {issue.Title}", EmbedColors.IssueLocked),
+        "unlocked" => ($"Issue unlocked: #{issue.Number} {issue.Title}", EmbedColors.IssueUnlocked),
+        "transferred" => ($"Issue transferred: #{issue.Number} {issue.Title}", EmbedColors.IssueTransferred),
+        "pinned" => ($"Issue pinned: #{issue.Number} {issue.Title}", EmbedColors.IssuePinned),
+        "unpinned" => ($"Issue unpinned: #{issue.Number} {issue.Title}", EmbedColors.IssueUnpinned),
+        "deleted" => ($"Issue deleted: #{issue.Number} {issue.Title}", EmbedColors.IssueDeleted),
+        _ => ($"Issue {action}: #{issue.Number} {issue.Title}", EmbedColors.Unknown),
+    };
+
+    /// <summary>埋め込みフィールド一覧を組み立てる</summary>
+    private static List<DiscordEmbedField> BuildFields(
+        Repository repo,
+        Issue issue,
+        Label? label,
+        User? assignee,
+        Milestone? milestone)
+    {
         var fields = new List<DiscordEmbedField>
         {
             new("Repository", $"[{repo.FullName}]({repo.HtmlUrl})", true),
-            new("State", issue.State.StringValue, true),
+            new("State", issue.State?.StringValue ?? "unknown", true),
         };
 
         if (label is not null)
@@ -75,42 +114,31 @@ public sealed class IssuesAction(
         if (milestone is not null)
             fields.Add(new("Milestone", milestone.Title, true));
 
-        var description = issue.Body is not null && issue.Body.Length > 0
-            ? (issue.Body.Length > 500 ? $"{issue.Body[..500]}..." : issue.Body)
-            : null;
+        return fields;
+    }
 
+    /// <summary>本文（edited イベントの場合はタイトル変更の diff）を組み立てる</summary>
+    private static string? BuildDescription(string action, Issue issue, Octokit.Webhooks.Models.IssuesEvent.Changes? changes)
+    {
         // edited イベントの場合、タイトル変更の diff を description として生成する
-        if (Event.Action == "edited" && changes?.Title?.From is not null)
+        if (action == "edited" && changes?.Title?.From is not null)
         {
-            var oldTitle = changes.Title.From;
-            var patch = CreatePatch(oldTitle, issue.Title, "title");
-            description = $"```diff\n{patch}```";
+            var patch = CreatePatch(changes.Title.From, issue.Title, "title");
+            return $"```diff\n{patch}```";
         }
 
-        var author = new DiscordEmbedAuthor(
-            Name: sender.Login,
-            Url: Uri.TryCreate(sender.HtmlUrl, UriKind.Absolute, out var senderUrl) ? senderUrl : null,
-            IconUrl: Uri.TryCreate(sender.AvatarUrl, UriKind.Absolute, out var avatarUrl) ? avatarUrl : null);
-
-        DiscordEmbed embed = EmbedHelper.CreateEmbed(
-            eventName: EventName,
-            color: color,
-            title: title,
-            description: description,
-            url: Uri.TryCreate(issue.HtmlUrl, UriKind.Absolute, out var issueUrl) ? issueUrl : null,
-            author: author,
-            fields: fields);
-
-        // アクション別キー（同一性質のペアは共通キーで編集対象を統一）
-        var keySuffix = Event.Action switch
-        {
-            "assigned" or "unassigned" => "assigned",
-            "labeled" or "unlabeled" => "label",
-            "locked" or "unlocked" => "locked",
-            "milestoned" or "demilestoned" => "milestoned",
-            _ => Event.Action,
-        };
-        var key = $"{repo.FullName}#{issue.Number}-{keySuffix}";
-        await SendMessageAsync(key, new DiscordMessage(Embeds: [embed]));
+        return issue.Body is not null && issue.Body.Length > 0
+            ? (issue.Body.Length > 500 ? $"{issue.Body[..500]}..." : issue.Body)
+            : null;
     }
+
+    /// <summary>同一性質のアクションペアを共通キーに統一する</summary>
+    private static string GetKeySuffix(string action) => action switch
+    {
+        "assigned" or "unassigned" => "assigned",
+        "labeled" or "unlabeled" => "label",
+        "locked" or "unlocked" => "locked",
+        "milestoned" or "demilestoned" => "milestoned",
+        _ => action,
+    };
 }

--- a/src/Actions/Impl/IssuesAction.cs
+++ b/src/Actions/Impl/IssuesAction.cs
@@ -7,6 +7,7 @@ using Octokit.Webhooks;
 using Octokit.Webhooks.Events;
 using Octokit.Webhooks.Events.Issues;
 using Octokit.Webhooks.Models;
+using IssuesEventChanges = Octokit.Webhooks.Models.IssuesEvent.Changes;
 
 namespace GitHubWebhookBridge.Actions.Impl;
 
@@ -45,7 +46,7 @@ public sealed class IssuesAction(
                          ?? (Event as IssuesUnassignedEvent)?.Assignee;
         Milestone? milestone = (Event as IssuesMilestonedEvent)?.Milestone
                                ?? (Event as IssuesDemilestonedEvent)?.Milestone;
-        Octokit.Webhooks.Models.IssuesEvent.Changes? changes = (Event as IssuesEditedEvent)?.Changes;
+        IssuesEventChanges? changes = (Event as IssuesEditedEvent)?.Changes;
 
         List<DiscordEmbedField> fields = BuildFields(repo, issue, label, assignee, milestone);
         var description = BuildDescription(action, issue, changes);
@@ -119,7 +120,7 @@ public sealed class IssuesAction(
     }
 
     /// <summary>本文（edited イベントの場合はタイトル変更の diff）を組み立てる</summary>
-    private static string? BuildDescription(string action, Issue issue, Octokit.Webhooks.Models.IssuesEvent.Changes? changes)
+    private static string? BuildDescription(string action, Issue issue, IssuesEventChanges? changes)
     {
         // edited イベントの場合、タイトル変更の diff を description として生成する
         if (action == "edited" && changes?.Title?.From is not null)

--- a/src/Actions/Impl/PingAction.cs
+++ b/src/Actions/Impl/PingAction.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using GitHubWebhookBridge.Managers;
 using GitHubWebhookBridge.Models.Discord;
 using GitHubWebhookBridge.Services;
@@ -31,8 +32,8 @@ public sealed class PingAction(
             description: Event.Zen,
             fields: [
                 new("Hook Type", Event.Hook?.Type.StringValue ?? "N/A", true),
-                new("Hook ID", Event.HookId.ToString(System.Globalization.CultureInfo.InvariantCulture), true),
-                new("Events", (Event.Hook?.Events?.Count ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture), true),
+                new("Hook ID", Event.HookId.ToString(CultureInfo.InvariantCulture), true),
+                new("Events", (Event.Hook?.Events?.Count ?? 0).ToString(CultureInfo.InvariantCulture), true),
                 new("Repository", Event.Repository?.FullName ?? "N/A", true),
                 new("Sender", Event.Sender?.Login ?? "N/A", true),
                 new("Organization", Event.Organization?.Login ?? "N/A", true),

--- a/src/Actions/Impl/PublicAction.cs
+++ b/src/Actions/Impl/PublicAction.cs
@@ -24,19 +24,25 @@ public sealed class PublicAction(
     /// <inheritdoc/>
     public override async Task RunAsync()
     {
+        if (Event.Sender is not { } sender || Event.Repository is not { } repo)
+        {
+            Logger.LogWarning("public payload is missing sender or repository; skipping notification.");
+            return;
+        }
+
         var author = new DiscordEmbedAuthor(
-            Name: Event.Sender.Login,
-            Url: Uri.TryCreate(Event.Sender.HtmlUrl, UriKind.Absolute, out var senderUrl) ? senderUrl : null,
-            IconUrl: Uri.TryCreate(Event.Sender.AvatarUrl, UriKind.Absolute, out var avatarUrl) ? avatarUrl : null);
+            Name: sender.Login,
+            Url: Uri.TryCreate(sender.HtmlUrl, UriKind.Absolute, out Uri? senderUrl) ? senderUrl : null,
+            IconUrl: Uri.TryCreate(sender.AvatarUrl, UriKind.Absolute, out Uri? avatarUrl) ? avatarUrl : null);
 
         DiscordEmbed embed = EmbedHelper.CreateEmbed(
             eventName: EventName,
             color: EmbedColors.Public,
-            title: $"Published {Event.Repository.FullName} by {Event.Sender.Login}",
-            url: Uri.TryCreate(Event.Repository.HtmlUrl, UriKind.Absolute, out var repoUrl) ? repoUrl : null,
+            title: $"Published {repo.FullName} by {sender.Login}",
+            url: Uri.TryCreate(repo.HtmlUrl, UriKind.Absolute, out Uri? repoUrl) ? repoUrl : null,
             author: author);
 
-        var key = $"{Event.Repository.FullName}-public-{Event.Sender.Login}";
+        var key = $"{repo.FullName}-public-{sender.Login}";
         await SendMessageAsync(key, new DiscordMessage(Embeds: [embed]));
     }
 }

--- a/src/Actions/Impl/PullRequestAction.cs
+++ b/src/Actions/Impl/PullRequestAction.cs
@@ -93,7 +93,8 @@ public sealed class PullRequestAction(
         }
 
         OctokitPR pr = Event.PullRequest;
-        var action = Event.Action ?? string.Empty;
+        // 通知タイトルとキャッシュキーの一意性を保つため、欠損時は空文字ではなく明示的な既定値を使う
+        var action = Event.Action ?? "unknown";
 
         // サブタイプ固有プロパティをパターンマッチで取得する
         Label? label = (Event as PullRequestLabeledEvent)?.Label

--- a/src/Actions/Impl/PullRequestAction.cs
+++ b/src/Actions/Impl/PullRequestAction.cs
@@ -137,11 +137,11 @@ public sealed class PullRequestAction(
         User? assignee,
         User? requestedReviewer)
     {
-        // Octokit の PullRequest では Additions/Deletions は long（常に存在）
         var fields = new List<DiscordEmbedField>
         {
             new("Repository", $"[{repo.FullName}]({repo.HtmlUrl})", true),
             new("Branch", $"`{pr.Head.Ref}` → `{pr.Base.Ref}`", true),
+            // Octokit の PullRequest では Additions/Deletions は long（常に存在）
             new("Changes", $"+{pr.Additions} / -{pr.Deletions} ({pr.ChangedFiles} files)", true),
         };
 

--- a/src/Actions/Impl/PullRequestAction.cs
+++ b/src/Actions/Impl/PullRequestAction.cs
@@ -26,7 +26,7 @@ public sealed class PullRequestAction(
     : BaseAction<PullRequestEvent>(discord, webhookUrl, eventName, pullRequestEvent, cache, userMapManager, logger)
 {
     /// <summary>アクションに対応するキャッシュキーのサフィックスを取得する</summary>
-    private string GetCacheKeySuffix() => Event.Action switch
+    private static string GetCacheKeySuffix(string action) => action switch
     {
         "assigned" or "unassigned" => "assigned",
         "labeled" or "unlabeled" => "label",
@@ -35,12 +35,12 @@ public sealed class PullRequestAction(
         "milestoned" or "demilestoned" => "milestoned",
         "review_requested" or "review_request_removed" => "review_requested",
         "enqueued" or "dequeued" => "enqueued",
-        _ => Event.Action,
+        _ => action,
     };
 
     /// <summary>PR とアクションに対応するキャッシュキーを取得する</summary>
-    private string GetCacheKey() =>
-        $"{Event.Repository.FullName}#{Event.PullRequest.Number}-{GetCacheKeySuffix()}";
+    private static string GetCacheKey(Repository repo, OctokitPR pr, string action) =>
+        $"{repo.FullName}#{pr.Number}-{GetCacheKeySuffix(action)}";
 
     /// <summary>タイトルが WIP（作業中）かどうかを判定する</summary>
     private static bool IsWipTitle(string title) =>
@@ -86,9 +86,14 @@ public sealed class PullRequestAction(
         // synchronize はコミット追加時に発生するが通知不要なためスキップ
         if (Event.Action == "synchronize") return;
 
+        if (Event.Repository is not { } repo || Event.Sender is not { } sender)
+        {
+            Logger.LogWarning("pull_request payload is missing repository or sender; skipping notification.");
+            return;
+        }
+
         OctokitPR pr = Event.PullRequest;
-        Repository repo = Event.Repository;
-        User sender = Event.Sender;
+        var action = Event.Action ?? string.Empty;
 
         // サブタイプ固有プロパティをパターンマッチで取得する
         Label? label = (Event as PullRequestLabeledEvent)?.Label
@@ -99,7 +104,7 @@ public sealed class PullRequestAction(
         Octokit.Webhooks.Models.PullRequestEvent.PullRequestEditedEventChanges? changes =
             (Event as PullRequestEditedEvent)?.Changes;
 
-        (var titleVerb, var color) = GetTitleVerbAndColor(Event.Action, pr.Merged == true);
+        (var titleVerb, var color) = GetTitleVerbAndColor(action, pr.Merged == true);
 
         var title = $"PR {titleVerb}: #{pr.Number} {pr.Title}";
         List<DiscordEmbedField> fields = BuildFields(pr, repo, label, assignee, requestedReviewer);
@@ -108,35 +113,37 @@ public sealed class PullRequestAction(
 
         var author = new DiscordEmbedAuthor(
             Name: sender.Login,
-            Url: Uri.TryCreate(sender.HtmlUrl, UriKind.Absolute, out var senderUrl) ? senderUrl : null,
-            IconUrl: Uri.TryCreate(sender.AvatarUrl, UriKind.Absolute, out var avatarUrl) ? avatarUrl : null);
+            Url: Uri.TryCreate(sender.HtmlUrl, UriKind.Absolute, out Uri? senderUrl) ? senderUrl : null,
+            IconUrl: Uri.TryCreate(sender.AvatarUrl, UriKind.Absolute, out Uri? avatarUrl) ? avatarUrl : null);
 
         DiscordEmbed embed = EmbedHelper.CreateEmbed(
             eventName: EventName,
             color: color,
             title: title,
             description: description,
-            url: Uri.TryCreate(pr.HtmlUrl, UriKind.Absolute, out var prUrl) ? prUrl : null,
+            url: Uri.TryCreate(pr.HtmlUrl, UriKind.Absolute, out Uri? prUrl) ? prUrl : null,
             author: author,
             fields: fields);
 
-        var key = GetCacheKey();
+        var key = GetCacheKey(repo, pr, action);
         await SendMessageAsync(key, new DiscordMessage(Content: content, Embeds: [embed]));
     }
 
     /// <summary>PR の各種情報を Embed フィールドのリストとして構築する</summary>
     private static List<DiscordEmbedField> BuildFields(
-        OctokitPR pr, Repository repo,
-        Label? label, User? assignee, User? requestedReviewer)
+        OctokitPR pr,
+        Repository repo,
+        Label? label,
+        User? assignee,
+        User? requestedReviewer)
     {
+        // Octokit の PullRequest では Additions/Deletions は long（常に存在）
         var fields = new List<DiscordEmbedField>
         {
             new("Repository", $"[{repo.FullName}]({repo.HtmlUrl})", true),
             new("Branch", $"`{pr.Head.Ref}` → `{pr.Base.Ref}`", true),
+            new("Changes", $"+{pr.Additions} / -{pr.Deletions} ({pr.ChangedFiles} files)", true),
         };
-
-        // Octokit の PullRequest では Additions/Deletions は long（常に存在）
-        fields.Add(new("Changes", $"+{pr.Additions} / -{pr.Deletions} ({pr.ChangedFiles} files)", true));
 
         if (pr.Draft)
             fields.Add(new("Status", "Draft", true));
@@ -158,8 +165,10 @@ public sealed class PullRequestAction(
     /// Draft PR および WIP タイトル解除前はメンションを抑制する
     /// </summary>
     private async Task<string?> BuildContentAsync(
-        OctokitPR pr, User sender,
-        User? assignee, User? requestedReviewer,
+        OctokitPR pr,
+        User sender,
+        User? assignee,
+        User? requestedReviewer,
         Octokit.Webhooks.Models.PullRequestEvent.PullRequestEditedEventChanges? changes)
     {
         string? content = null;

--- a/src/Actions/Impl/PullRequestAction.cs
+++ b/src/Actions/Impl/PullRequestAction.cs
@@ -9,6 +9,7 @@ using Octokit.Webhooks.Events;
 using Octokit.Webhooks.Events.PullRequest;
 using Octokit.Webhooks.Models;
 using OctokitPR = Octokit.Webhooks.Models.PullRequestEvent.PullRequest;
+using PullRequestEditedEventChanges = Octokit.Webhooks.Models.PullRequestEvent.PullRequestEditedEventChanges;
 
 namespace GitHubWebhookBridge.Actions.Impl;
 
@@ -102,7 +103,7 @@ public sealed class PullRequestAction(
         User? assignee = (Event as PullRequestAssignedEvent)?.Assignee
                          ?? (Event as PullRequestUnassignedEvent)?.Assignee;
         User? requestedReviewer = (Event as PullRequestReviewRequestedEvent)?.RequestedReviewer;
-        Octokit.Webhooks.Models.PullRequestEvent.PullRequestEditedEventChanges? changes =
+        PullRequestEditedEventChanges? changes =
             (Event as PullRequestEditedEvent)?.Changes;
 
         (var titleVerb, var color) = GetTitleVerbAndColor(action, pr.Merged == true);
@@ -170,7 +171,7 @@ public sealed class PullRequestAction(
         User sender,
         User? assignee,
         User? requestedReviewer,
-        Octokit.Webhooks.Models.PullRequestEvent.PullRequestEditedEventChanges? changes)
+        PullRequestEditedEventChanges? changes)
     {
         string? content = null;
 
@@ -218,7 +219,7 @@ public sealed class PullRequestAction(
     /// </summary>
     private string? BuildDescription(
         OctokitPR pr,
-        Octokit.Webhooks.Models.PullRequestEvent.PullRequestEditedEventChanges? changes)
+        PullRequestEditedEventChanges? changes)
     {
         if (Event.Action is not ("opened" or "edited"))
             return null;

--- a/src/Actions/Impl/PullRequestReviewAction.cs
+++ b/src/Actions/Impl/PullRequestReviewAction.cs
@@ -28,11 +28,15 @@ public sealed class PullRequestReviewAction(
     {
         OctokitReview review = Event.Review;
         SimplePullRequest pr = Event.PullRequest;
-        Repository repo = Event.Repository;
-        User sender = Event.Sender;
+
+        if (Event.Repository is not { } repo || Event.Sender is not { } sender)
+        {
+            Logger.LogWarning("pull_request_review payload is missing repository or sender; skipping notification.");
+            return;
+        }
 
         // レビュー状態とアクションを組み合わせて色とタイトルを決定する
-        (var titleVerb, var color) = (Event.Action, review.State.StringValue?.ToUpperInvariant() ?? string.Empty) switch
+        (var titleVerb, var color) = (Event.Action, review.State?.StringValue?.ToUpperInvariant() ?? string.Empty) switch
         {
             ("submitted", "APPROVED") => ("approved", EmbedColors.PullRequestReviewApproved),
             ("submitted", "CHANGES_REQUESTED") => ("requested changes", EmbedColors.PullRequestReviewChangesRequested),
@@ -56,15 +60,15 @@ public sealed class PullRequestReviewAction(
 
         var author = new DiscordEmbedAuthor(
             Name: sender.Login,
-            Url: Uri.TryCreate(sender.HtmlUrl, UriKind.Absolute, out var senderUrl) ? senderUrl : null,
-            IconUrl: Uri.TryCreate(sender.AvatarUrl, UriKind.Absolute, out var avatarUrl) ? avatarUrl : null);
+            Url: Uri.TryCreate(sender.HtmlUrl, UriKind.Absolute, out Uri? senderUrl) ? senderUrl : null,
+            IconUrl: Uri.TryCreate(sender.AvatarUrl, UriKind.Absolute, out Uri? avatarUrl) ? avatarUrl : null);
 
         DiscordEmbed embed = EmbedHelper.CreateEmbed(
             eventName: EventName,
             color: color,
             title: title,
             description: body,
-            url: Uri.TryCreate(review.HtmlUrl, UriKind.Absolute, out var reviewUrl) ? reviewUrl : null,
+            url: Uri.TryCreate(review.HtmlUrl, UriKind.Absolute, out Uri? reviewUrl) ? reviewUrl : null,
             author: author);
 
         var key = $"{repo.FullName}-pr-review-{review.Id.ToString(System.Globalization.CultureInfo.InvariantCulture)}";

--- a/src/Actions/Impl/PullRequestReviewAction.cs
+++ b/src/Actions/Impl/PullRequestReviewAction.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using GitHubWebhookBridge.Managers;
 using GitHubWebhookBridge.Models.Discord;
 using GitHubWebhookBridge.Services;
@@ -71,7 +72,7 @@ public sealed class PullRequestReviewAction(
             url: Uri.TryCreate(review.HtmlUrl, UriKind.Absolute, out Uri? reviewUrl) ? reviewUrl : null,
             author: author);
 
-        var key = $"{repo.FullName}-pr-review-{review.Id.ToString(System.Globalization.CultureInfo.InvariantCulture)}";
+        var key = $"{repo.FullName}-pr-review-{review.Id.ToString(CultureInfo.InvariantCulture)}";
         await SendMessageAsync(key, new DiscordMessage(Content: content, Embeds: [embed]));
     }
 }

--- a/src/Actions/Impl/PullRequestReviewCommentAction.cs
+++ b/src/Actions/Impl/PullRequestReviewCommentAction.cs
@@ -27,8 +27,12 @@ public sealed class PullRequestReviewCommentAction(
     {
         PullRequestReviewComment comment = Event.Comment;
         SimplePullRequest pr = Event.PullRequest;
-        Repository repo = Event.Repository;
-        User sender = Event.Sender;
+
+        if (Event.Repository is not { } repo || Event.Sender is not { } sender)
+        {
+            Logger.LogWarning("pull_request_review_comment payload is missing repository or sender; skipping notification.");
+            return;
+        }
 
         (var titleVerb, var color) = Event.Action switch
         {
@@ -65,15 +69,15 @@ public sealed class PullRequestReviewCommentAction(
 
         var author = new DiscordEmbedAuthor(
             Name: sender.Login,
-            Url: Uri.TryCreate(sender.HtmlUrl, UriKind.Absolute, out var senderUrl) ? senderUrl : null,
-            IconUrl: Uri.TryCreate(sender.AvatarUrl, UriKind.Absolute, out var avatarUrl) ? avatarUrl : null);
+            Url: Uri.TryCreate(sender.HtmlUrl, UriKind.Absolute, out Uri? senderUrl) ? senderUrl : null,
+            IconUrl: Uri.TryCreate(sender.AvatarUrl, UriKind.Absolute, out Uri? avatarUrl) ? avatarUrl : null);
 
         DiscordEmbed embed = EmbedHelper.CreateEmbed(
             eventName: EventName,
             color: color,
             title: title,
             description: body,
-            url: Uri.TryCreate(comment.HtmlUrl, UriKind.Absolute, out var commentUrl) ? commentUrl : null,
+            url: Uri.TryCreate(comment.HtmlUrl, UriKind.Absolute, out Uri? commentUrl) ? commentUrl : null,
             author: author,
             fields: fields.Count > 0 ? fields : null);
 

--- a/src/Actions/Impl/PullRequestReviewCommentAction.cs
+++ b/src/Actions/Impl/PullRequestReviewCommentAction.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using GitHubWebhookBridge.Managers;
 using GitHubWebhookBridge.Models.Discord;
 using GitHubWebhookBridge.Services;
@@ -81,7 +82,7 @@ public sealed class PullRequestReviewCommentAction(
             author: author,
             fields: fields.Count > 0 ? fields : null);
 
-        var key = $"{repo.FullName}-pr-review-comment-{comment.Id.ToString(System.Globalization.CultureInfo.InvariantCulture)}";
+        var key = $"{repo.FullName}-pr-review-comment-{comment.Id.ToString(CultureInfo.InvariantCulture)}";
         await SendMessageAsync(key, new DiscordMessage(Content: content, Embeds: [embed]));
     }
 }

--- a/src/Actions/Impl/PullRequestReviewThreadAction.cs
+++ b/src/Actions/Impl/PullRequestReviewThreadAction.cs
@@ -30,8 +30,12 @@ public sealed class PullRequestReviewThreadAction(
         // 実データを持つ AdditionalProperties["thread"].node_id をスレッド識別子として使用する
         var threadNodeId = GetThreadNodeId();
         SimplePullRequest pr = Event.PullRequest;
-        Repository repo = Event.Repository;
-        User sender = Event.Sender;
+
+        if (Event.Repository is not { } repo || Event.Sender is not { } sender)
+        {
+            Logger.LogWarning("pull_request_review_thread payload is missing repository or sender; skipping notification.");
+            return;
+        }
 
         var resolved = Event.Action == "resolved";
 
@@ -58,14 +62,14 @@ public sealed class PullRequestReviewThreadAction(
 
         var author = new DiscordEmbedAuthor(
             Name: sender.Login,
-            Url: Uri.TryCreate(sender.HtmlUrl, UriKind.Absolute, out var senderUrl) ? senderUrl : null,
-            IconUrl: Uri.TryCreate(sender.AvatarUrl, UriKind.Absolute, out var avatarUrl) ? avatarUrl : null);
+            Url: Uri.TryCreate(sender.HtmlUrl, UriKind.Absolute, out Uri? senderUrl) ? senderUrl : null,
+            IconUrl: Uri.TryCreate(sender.AvatarUrl, UriKind.Absolute, out Uri? avatarUrl) ? avatarUrl : null);
 
         DiscordEmbed embed = EmbedHelper.CreateEmbed(
             eventName: EventName,
             color: color,
             title: title,
-            url: Uri.TryCreate(pr.HtmlUrl, UriKind.Absolute, out var prUrl) ? prUrl : null,
+            url: Uri.TryCreate(pr.HtmlUrl, UriKind.Absolute, out Uri? prUrl) ? prUrl : null,
             author: author,
             fields: fields);
 

--- a/src/Actions/Impl/PushAction.cs
+++ b/src/Actions/Impl/PushAction.cs
@@ -38,19 +38,25 @@ public sealed class PushAction(
         var commits = allCommits.Take(CommitLimit).ToList();
         var description = GetDescription(commits, allCommits.Count);
 
+        if (Event.Sender is not { } sender || Event.Repository is not { } repo)
+        {
+            Logger.LogWarning("push payload is missing sender or repository; skipping notification.");
+            return;
+        }
+
         var author = new DiscordEmbedAuthor(
-            Name: Event.Sender.Login,
-            Url: Uri.TryCreate(Event.Sender.HtmlUrl, UriKind.Absolute, out var senderUrl) ? senderUrl : null,
-            IconUrl: Uri.TryCreate(Event.Sender.AvatarUrl, UriKind.Absolute, out var avatarUrl) ? avatarUrl : null);
+            Name: sender.Login,
+            Url: Uri.TryCreate(sender.HtmlUrl, UriKind.Absolute, out Uri? senderUrl) ? senderUrl : null,
+            IconUrl: Uri.TryCreate(sender.AvatarUrl, UriKind.Absolute, out Uri? avatarUrl) ? avatarUrl : null);
 
         DiscordEmbed embed = EmbedHelper.CreateEmbed(
             eventName: EventName,
             color: EmbedColors.Push,
-            title: $"[{Event.Repository.FullName}:{shortRef}] {allCommits.Count} new commit(s)",
+            title: $"[{repo.FullName}:{shortRef}] {allCommits.Count} new commit(s)",
             description: description,
             author: author);
 
-        var key = $"{Event.Repository.FullName}:{Event.Ref}";
+        var key = $"{repo.FullName}:{Event.Ref}";
         await SendMessageAsync(key, new DiscordMessage(Embeds: [embed]));
     }
 

--- a/src/Actions/Impl/StarAction.cs
+++ b/src/Actions/Impl/StarAction.cs
@@ -24,22 +24,28 @@ public sealed class StarAction(
     /// <inheritdoc/>
     public override async Task RunAsync()
     {
+        if (Event.Sender is not { } sender || Event.Repository is not { } repo)
+        {
+            Logger.LogWarning("star payload is missing sender or repository; skipping notification.");
+            return;
+        }
+
         var titlePrefix = Event.Action == "created" ? "Starred" : "Unstarred";
         var color = Event.Action == "created" ? EmbedColors.Star : EmbedColors.Unstar;
 
         var author = new DiscordEmbedAuthor(
-            Name: Event.Sender.Login,
-            Url: Uri.TryCreate(Event.Sender.HtmlUrl, UriKind.Absolute, out var senderUrl) ? senderUrl : null,
-            IconUrl: Uri.TryCreate(Event.Sender.AvatarUrl, UriKind.Absolute, out var avatarUrl) ? avatarUrl : null);
+            Name: sender.Login,
+            Url: Uri.TryCreate(sender.HtmlUrl, UriKind.Absolute, out Uri? senderUrl) ? senderUrl : null,
+            IconUrl: Uri.TryCreate(sender.AvatarUrl, UriKind.Absolute, out Uri? avatarUrl) ? avatarUrl : null);
 
         DiscordEmbed embed = EmbedHelper.CreateEmbed(
             eventName: EventName,
             color: color,
-            title: $"{titlePrefix} {Event.Repository.FullName} by {Event.Sender.Login}",
-            url: Uri.TryCreate(Event.Repository.HtmlUrl, UriKind.Absolute, out var repoUrl) ? repoUrl : null,
+            title: $"{titlePrefix} {repo.FullName} by {sender.Login}",
+            url: Uri.TryCreate(repo.HtmlUrl, UriKind.Absolute, out Uri? repoUrl) ? repoUrl : null,
             author: author);
 
-        var key = $"{Event.Repository.FullName}-star-{Event.Sender.Login}";
+        var key = $"{repo.FullName}-star-{sender.Login}";
         await SendMessageAsync(key, new DiscordMessage(Embeds: [embed]));
     }
 }

--- a/src/Functions/WebhookFunction.cs
+++ b/src/Functions/WebhookFunction.cs
@@ -143,6 +143,7 @@ public class WebhookFunction(
         {
             // デシリアライズに失敗した場合（例: sender.id が非数値）はミュートチェックをスキップして処理を続行する
         }
+
         if (envelope?.Sender?.Id is { } senderId)
         {
             if (_muteManager.IsMuted(senderId, eventName, envelope.Action))

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -12,7 +12,7 @@ using OpenTelemetry;
 // Windows Consumption プランで「Timed out waiting for the function start call」という
 // 既知の未解決バグ（Azure/azure-functions-dotnet-worker#3348）を抱えているため使用しない。
 // 標準の ConfigureFunctionsWorkerDefaults（HttpRequestData/HttpResponseData ベース）を使用する
-IHostBuilder hostBuilder = new HostBuilder();
+HostBuilder hostBuilder = new();
 hostBuilder.ConfigureFunctionsWorkerDefaults();
 
 hostBuilder.ConfigureServices(services =>

--- a/src/Services/ActionRegistryValidator.cs
+++ b/src/Services/ActionRegistryValidator.cs
@@ -17,8 +17,12 @@ public sealed class ActionRegistryValidator(ActionFactory factory, IServiceProvi
         var dummyUri = new Uri("https://example.invalid");
         const string dummyEventName = "__startup_validate__";
 
-        foreach (var (eventName, (actionType, payloadType)) in factory.Registry)
+        foreach (KeyValuePair<string, (Type Action, Type Payload)> item in factory.Registry)
         {
+            var eventName = item.Key;
+            Type actionType = item.Value.Action;
+            Type payloadType = item.Value.Payload;
+
             // `{}` で初期化できない型（required メンバーを持つ Octokit 型）に備え、
             // デシリアライズ失敗を捕捉してスキップする（ペイロード生成の失敗はアクション実装の問題ではない）。
             object dummy;
@@ -44,7 +48,8 @@ public sealed class ActionRegistryValidator(ActionFactory factory, IServiceProvi
                 throw new InvalidOperationException(
                     $"ActionRegistryValidator: failed to instantiate '{actionType.Name}' for event '{eventName}'. " +
                     $"Ensure all DI dependencies are registered in Program.cs. " +
-                    $"Inner: {ex.Message}", ex);
+                    $"Inner: {ex.Message}",
+                    ex);
             }
         }
     }

--- a/src/Utils/JsonResponseHelper.cs
+++ b/src/Utils/JsonResponseHelper.cs
@@ -9,7 +9,7 @@ public static class JsonResponseHelper
 {
     /// <summary>
     /// <c>{ "message": ... }</c> 形式の JSON レスポンスを生成する。
-    /// <see cref="HttpResponseData.WriteAsJsonAsync{T}(T, CancellationToken)"/> は
+    /// <c>HttpResponseData.WriteAsJsonAsync</c> は
     /// <c>WorkerOptions.Serializer</c> の DI 解決に依存するため、
     /// それを必要としない <c>WriteStringAsync</c> ベースで明示的にシリアライズする
     /// </summary>

--- a/tests/WebhookFunctionTests.cs
+++ b/tests/WebhookFunctionTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Specialized;
+using System.Globalization;
 using System.Net;
 using System.Security.Cryptography;
 using System.Text;
@@ -29,7 +30,7 @@ public class WebhookFunctionTests
     }
 
     /// <summary>テスト用 <see cref="HttpRequestData"/> を組み立てる。</summary>
-    private static HttpRequestData BuildRequest(
+    private static FakeHttpRequestData BuildRequest(
         string body,
         string secret,
         string eventName,
@@ -43,7 +44,7 @@ public class WebhookFunctionTests
         var context = new FakeFunctionContext();
 
         HttpHeadersCollection headers = [];
-        headers.Add("Content-Length", (contentLengthOverride ?? bodyBytes.LongLength).ToString());
+        headers.Add("Content-Length", (contentLengthOverride ?? bodyBytes.LongLength).ToString(CultureInfo.InvariantCulture));
 
         if (!omitSignature)
             headers.Add("X-Hub-Signature-256", ComputeSignature(bodyBytes, secret));
@@ -147,7 +148,7 @@ public class WebhookFunctionTests
         var body = Encoding.UTF8.GetBytes("{}");
         var context = new FakeFunctionContext();
         HttpHeadersCollection headers = [];
-        headers.Add("Content-Length", body.LongLength.ToString());
+        headers.Add("Content-Length", body.LongLength.ToString(CultureInfo.InvariantCulture));
         headers.Add("X-Hub-Signature-256", "sha256=deadbeef");
         headers.Add("X-GitHub-Event", "push");
         var req = new FakeHttpRequestData(context, new MemoryStream(body), headers, []);


### PR DESCRIPTION
## 概要

`dotnet build` で発生していた全警告を解消し、冗長・陳腐化したコメントを整理しました。

Closes #2644

## 対応内容

### 警告修正
- **null 参照警告 (CS8600/8602/8603/8604)**: `Actions/Impl/*.cs` 各アクションクラスに `Event.Repository`/`Event.Sender` のガード節を追加し、null 安全性を確保
- **CA1502 (循環的複雑度)**: `IssuesAction.cs` の `RunAsync()` からタイトル・色決定、フィールド構築、本文構築、キャッシュキー決定のロジックをそれぞれ専用メソッドへ抽出
- **CA1822 / CA1859**: 静的化可能なメソッドの `static` 化、`IHostBuilder`/`HttpRequestData` インターフェース型を具象型で保持するよう変更
- **CA1305 / CA1812**: テストコードの `long.ToString()` にカルチャ指定を追加、リフレクション経由でのみインスタンス化される型への CA1812 誤検知を `.editorconfig` の `[tests/**.cs]` ブロックで抑制（`#pragma` は未使用）
- **スタイル警告 (IDE0007/0008/0011/0028/0055/0290, SA1414/SA1117/SA1513, CS1574)**: フォーマット・タプル要素名・ブレース・XML doc cref の修正

### コメント整理
- コードベース全体を精査した結果、既存のコメントは「なぜ」を説明する規約に沿っており、大きな整理は不要と判断
- `PullRequestAction.cs` の型注釈コメントを該当フィールドの直前に配置し直し

### レビュー対応
- Copilot レビュー指摘を受け、`PullRequestAction.cs` / `IssuesAction.cs` の `Event.Action` が null の場合の既定値を空文字から `"unknown"` に変更（通知タイトル・キャッシュキーの一意性を確保）
- 完全修飾名を `using` ディレクティブ・型エイリアスに置き換え（`System.Globalization.CultureInfo` → `using System.Globalization;`、`Octokit.Webhooks.Models` のネスト型 → `using` エイリアス）

## 動作確認

- `dotnet build -c Release`: **0 Warning(s) / 0 Error(s)**
- `dotnet test -c Release`: **149/149 件成功**
- CI: 全チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
