### PR TITLE
fix: Discord embed の Repository フィールド重複表示を削除

### DIFF
--- a/src/Actions/Impl/DiscussionAction.cs
+++ b/src/Actions/Impl/DiscussionAction.cs
@@ -60,10 +60,7 @@ public sealed class DiscussionAction(
         DiscussionAnswer? answer = (Event as DiscussionAnsweredEvent)?.Answer;
         DiscussionCategory? newCategory = (Event as DiscussionCategoryChangedEvent)?.Changes?.Category?.From;
 
-        var fields = new List<DiscordEmbedField>
-        {
-            new("Repository", $"[{repo.FullName}]({repo.HtmlUrl})", true),
-        };
+        var fields = new List<DiscordEmbedField>();
 
         if (discussion.Category is not null)
             fields.Add(new("Category", discussion.Category.Name, true));

--- a/src/Actions/Impl/IssuesAction.cs
+++ b/src/Actions/Impl/IssuesAction.cs
@@ -48,7 +48,7 @@ public sealed class IssuesAction(
                                ?? (Event as IssuesDemilestonedEvent)?.Milestone;
         IssuesEventChanges? changes = (Event as IssuesEditedEvent)?.Changes;
 
-        List<DiscordEmbedField> fields = BuildFields(repo, issue, label, assignee, milestone);
+        List<DiscordEmbedField> fields = BuildFields(issue, label, assignee, milestone);
         var description = BuildDescription(action, issue, changes);
 
         var author = new DiscordEmbedAuthor(
@@ -95,7 +95,6 @@ public sealed class IssuesAction(
 
     /// <summary>Builds the list of embed fields.</summary>
     private static List<DiscordEmbedField> BuildFields(
-        Repository repo,
         Issue issue,
         Label? label,
         User? assignee,
@@ -103,7 +102,6 @@ public sealed class IssuesAction(
     {
         var fields = new List<DiscordEmbedField>
         {
-            new("Repository", $"[{repo.FullName}]({repo.HtmlUrl})", true),
             new("State", issue.State?.StringValue ?? "unknown", true),
         };
 

--- a/src/Actions/Impl/PingAction.cs
+++ b/src/Actions/Impl/PingAction.cs
@@ -34,7 +34,6 @@ public sealed class PingAction(
                 new("Hook Type", Event.Hook?.Type.StringValue ?? "N/A", true),
                 new("Hook ID", Event.HookId.ToString(CultureInfo.InvariantCulture), true),
                 new("Events", (Event.Hook?.Events?.Count ?? 0).ToString(CultureInfo.InvariantCulture), true),
-                new("Repository", Event.Repository?.FullName ?? "N/A", true),
                 new("Sender", Event.Sender?.Login ?? "N/A", true),
                 new("Organization", Event.Organization?.Login ?? "N/A", true),
             ]);

--- a/src/Actions/Impl/PullRequestAction.cs
+++ b/src/Actions/Impl/PullRequestAction.cs
@@ -109,7 +109,7 @@ public sealed class PullRequestAction(
         (var titleVerb, var color) = GetTitleVerbAndColor(action, pr.Merged == true);
 
         var title = $"PR {titleVerb}: #{pr.Number} {pr.Title}";
-        List<DiscordEmbedField> fields = BuildFields(pr, repo, label, assignee, requestedReviewer);
+        List<DiscordEmbedField> fields = BuildFields(pr, label, assignee, requestedReviewer);
         var content = await BuildContentAsync(pr, sender, assignee, requestedReviewer, changes);
         var description = BuildDescription(pr, changes);
 
@@ -134,14 +134,12 @@ public sealed class PullRequestAction(
     /// <summary>Builds the various PR details into a list of embed fields.</summary>
     private static List<DiscordEmbedField> BuildFields(
         OctokitPR pr,
-        Repository repo,
         Label? label,
         User? assignee,
         User? requestedReviewer)
     {
         var fields = new List<DiscordEmbedField>
         {
-            new("Repository", $"[{repo.FullName}]({repo.HtmlUrl})", true),
             new("Branch", $"`{pr.Head.Ref}` → `{pr.Base.Ref}`", true),
             // In Octokit's PullRequest, Additions/Deletions are long (always present).
             new("Changes", $"+{pr.Additions} / -{pr.Deletions} ({pr.ChangedFiles} files)", true),


### PR DESCRIPTION
## 概要

Ping / Issues / PullRequest / Discussion の各 Action で、Discord embed に "Repository" フィールドを表示していたが、repository 情報は embed のタイトルや URL(リンク)で既に表示されているため、フィールドとしての重複表示だった。他の Action(Push、Fork 等)は元々このフィールドを持っておらず、表記が Action ごとに不統一だった。

## 変更内容

- `src/Actions/Impl/PingAction.cs`: "Repository" フィールドを削除
- `src/Actions/Impl/IssuesAction.cs`: "Repository" フィールドを削除、`BuildFields` の未使用となった `repo` 引数を削除
- `src/Actions/Impl/PullRequestAction.cs`: "Repository" フィールドを削除、`BuildFields` の未使用となった `repo` 引数を削除
- `src/Actions/Impl/DiscussionAction.cs`: "Repository" フィールドを削除(`repo` はキャッシュキー生成で引き続き使用するため引数はそのまま)

Closes #2665