### PR TITLE
feat: show diff on issue/PR review comment edited

### DIFF
--- a/src/Actions/BaseAction.cs
+++ b/src/Actions/BaseAction.cs
@@ -132,4 +132,27 @@ public abstract class BaseAction<TEvent>(
 
         return sb.ToString();
     }
+
+    /// <summary>
+    /// Wraps a CreatePatch result in a ```diff code block for use as an Embed description.
+    /// Since the diffed source text is fully attacker-controlled (the comment author), this escapes
+    /// code-fence breakout sequences and truncates the result to stay within Discord's Embed
+    /// description limit (4096 characters).
+    /// </summary>
+    /// <param name="patch">The diff string returned by CreatePatch.</param>
+    /// <returns>A description string wrapped in a ```diff code block.</returns>
+    protected static string BuildDiffDescription(string patch)
+    {
+        ArgumentNullException.ThrowIfNull(patch);
+
+        // A run of 3 backticks in the diffed source text would close the code fence early, so
+        // neutralize it by inserting a visually near-identical zero-width space.
+        var escaped = patch.Replace("```", "``\u200b`", StringComparison.Ordinal);
+
+        const int maxLength = 4000; // Leaves headroom under the 4096-char Embed description limit for the fence markers.
+        if (escaped.Length > maxLength)
+            escaped = $"{escaped[..maxLength]}...\n";
+
+        return $"```diff\n{escaped}```";
+    }
 }

--- a/src/Actions/Impl/IssueCommentAction.cs
+++ b/src/Actions/Impl/IssueCommentAction.cs
@@ -6,7 +6,9 @@ using GitHubWebhookBridge.Utils;
 using Microsoft.Extensions.Logging;
 using Octokit.Webhooks;
 using Octokit.Webhooks.Events;
+using Octokit.Webhooks.Events.IssueComment;
 using Octokit.Webhooks.Models;
+using IssueCommentEventChanges = Octokit.Webhooks.Models.IssueCommentEvent.Changes;
 
 namespace GitHubWebhookBridge.Actions.Impl;
 
@@ -38,19 +40,21 @@ public sealed class IssueCommentAction(
         // Vary the type depending on whether the issue is a PR (it is a PR if IssuePullRequest.HtmlUrl is non-empty).
         var issueType = !string.IsNullOrEmpty(issue.PullRequest?.HtmlUrl) ? "PR" : "Issue";
 
-        (var titleVerb, var color) = Event.Action switch
+        // Use an explicit default rather than an empty string when missing, to keep the notification title unique.
+        var action = Event.Action ?? "unknown";
+
+        (var titleVerb, var color) = action switch
         {
             "created" => ("commented on", EmbedColors.IssueCommentCreated),
             "edited" => ("edited comment on", EmbedColors.IssueCommentEdited),
             "deleted" => ("deleted comment on", EmbedColors.IssueCommentDeleted),
-            _ => (Event.Action, EmbedColors.Unknown),
+            _ => (action, EmbedColors.Unknown),
         };
 
         var title = $"{sender.Login} {titleVerb} {issueType} #{issue.Number}: {issue.Title}";
 
-        var body = comment.Body is not null && comment.Body.Length > 0
-            ? (comment.Body.Length > 500 ? $"{comment.Body[..500]}..." : comment.Body)
-            : null;
+        IssueCommentEventChanges? changes = (Event as IssueCommentEditedEvent)?.Changes;
+        var body = BuildDescription(action, comment, changes);
 
         // @mention the issue author (excluding the sender).
         var mentions = await GetUsersMentionsAsync(
@@ -74,5 +78,20 @@ public sealed class IssueCommentAction(
 
         var key = $"{repo.FullName}-issue-comment-{comment.Id.ToString(CultureInfo.InvariantCulture)}";
         await SendMessageAsync(key, new DiscordMessage(Content: content, Embeds: [embed]));
+    }
+
+    /// <summary>Builds the description (a body-change diff for edited events).</summary>
+    private static string? BuildDescription(string action, IssueComment comment, IssueCommentEventChanges? changes)
+    {
+        // For edited events, render the body change as a diff description.
+        if (action == "edited" && changes?.Body?.From is not null)
+        {
+            var patch = CreatePatch(changes.Body.From, comment.Body ?? string.Empty, "comment");
+            return BuildDiffDescription(patch);
+        }
+
+        return comment.Body is not null && comment.Body.Length > 0
+            ? (comment.Body.Length > 500 ? $"{comment.Body[..500]}..." : comment.Body)
+            : null;
     }
 }

--- a/src/Actions/Impl/PullRequestReviewCommentAction.cs
+++ b/src/Actions/Impl/PullRequestReviewCommentAction.cs
@@ -6,7 +6,9 @@ using GitHubWebhookBridge.Utils;
 using Microsoft.Extensions.Logging;
 using Octokit.Webhooks;
 using Octokit.Webhooks.Events;
+using Octokit.Webhooks.Events.PullRequestReviewComment;
 using Octokit.Webhooks.Models;
+using PullRequestReviewCommentEventChanges = Octokit.Webhooks.Models.PullRequestReviewCommentEvent.Changes;
 
 namespace GitHubWebhookBridge.Actions.Impl;
 
@@ -35,20 +37,21 @@ public sealed class PullRequestReviewCommentAction(
             return;
         }
 
-        (var titleVerb, var color) = Event.Action switch
+        // Use an explicit default rather than an empty string when missing, to keep the notification title unique.
+        var action = Event.Action ?? "unknown";
+
+        (var titleVerb, var color) = action switch
         {
             "created" => ("commented on", EmbedColors.PullRequestReviewCommentCreated),
             "edited" => ("edited comment on", EmbedColors.PullRequestReviewCommentEdited),
             "deleted" => ("deleted comment on", EmbedColors.PullRequestReviewCommentDeleted),
-            _ => (Event.Action, EmbedColors.Unknown),
+            _ => (action, EmbedColors.Unknown),
         };
 
         var title = $"{sender.Login} {titleVerb} PR #{pr.Number}: {pr.Title}";
 
-        // Comment body (truncated if long).
-        var body = comment.Body is not null && comment.Body.Length > 0
-            ? (comment.Body.Length > 500 ? $"{comment.Body[..500]}..." : comment.Body)
-            : null;
+        PullRequestReviewCommentEventChanges? changes = (Event as PullRequestReviewCommentEditedEvent)?.Changes;
+        var body = BuildDescription(action, comment, changes);
 
         var fields = new List<DiscordEmbedField>();
         if (comment.Path is not null)
@@ -84,5 +87,23 @@ public sealed class PullRequestReviewCommentAction(
 
         var key = $"{repo.FullName}-pr-review-comment-{comment.Id.ToString(CultureInfo.InvariantCulture)}";
         await SendMessageAsync(key, new DiscordMessage(Content: content, Embeds: [embed]));
+    }
+
+    /// <summary>Builds the description (a body-change diff for edited events).</summary>
+    private static string? BuildDescription(
+        string action,
+        PullRequestReviewComment comment,
+        PullRequestReviewCommentEventChanges? changes)
+    {
+        // For edited events, render the body change as a diff description.
+        if (action == "edited" && changes?.Body?.From is not null)
+        {
+            var patch = CreatePatch(changes.Body.From, comment.Body ?? string.Empty, "comment");
+            return BuildDiffDescription(patch);
+        }
+
+        return comment.Body is not null && comment.Body.Length > 0
+            ? (comment.Body.Length > 500 ? $"{comment.Body[..500]}..." : comment.Body)
+            : null;
     }
 }

--- a/tests/IssueCommentActionTests.cs
+++ b/tests/IssueCommentActionTests.cs
@@ -36,9 +36,16 @@ public class IssueCommentActionTests
         string action = "created",
         bool isPullRequest = false,
         string commentBody = "LGTM",
-        long commentId = 9001) => JsonSerializer.Deserialize<IssueCommentEvent>(
-        $$"""{"action":"{{action}}","issue":{{TestFixtures.IssueJson(3,"Test issue",isPr:isPullRequest,userLogin:"issue-author",userId:10)}},"comment":{{TestFixtures.IssueCommentJson(commentId,commentBody)}},"repository":{{TestFixtures.RepoJson("test/repo")}},"sender":{{TestFixtures.UserJson("commenter",20)}}}""",
-        OctokitJsonOptions.Value)!;
+        long commentId = 9001,
+        string? changedBodyFrom = null)
+    {
+        var changesJson = action == "edited"
+            ? $$""","changes":{"body":{{(changedBodyFrom is not null ? $$"""{"from":"{{changedBodyFrom}}"}""" : "null")}}}"""
+            : "";
+        return JsonSerializer.Deserialize<IssueCommentEvent>(
+            $$"""{"action":"{{action}}","issue":{{TestFixtures.IssueJson(3,"Test issue",isPr:isPullRequest,userLogin:"issue-author",userId:10)}},"comment":{{TestFixtures.IssueCommentJson(commentId,commentBody)}},"repository":{{TestFixtures.RepoJson("test/repo")}},"sender":{{TestFixtures.UserJson("commenter",20)}}{{changesJson}}}""",
+            OctokitJsonOptions.Value)!;
+    }
 
     /// <summary>For created + a regular Issue, the title contains "Issue" and "commented on".</summary>
     [Fact]
@@ -136,6 +143,107 @@ public class IssueCommentActionTests
             d => d.SendMessageAsync(
                 It.IsAny<Uri>(),
                 It.Is<DiscordMessage>(m => m.Embeds![0].Description!.Contains("..."))),
+            Times.Once);
+    }
+
+    /// <summary>When the body actually changed on an edited event, the description becomes a diff code block.</summary>
+    [Fact]
+    public async Task RunAsyncEditedWithBodyChangeShowsDiff()
+    {
+        (Mock<IDiscordClient>? discord, Mock<IMessageCacheService>? cache, Mock<IGitHubUserMapManager>? userMap) = CreateMocks();
+
+        IssueCommentAction action = new(
+            discord.Object, cache.Object, userMap.Object,
+            Mock.Of<ILogger<IssueCommentAction>>(),
+            _webhookUri, "issue_comment",
+            MakeEvent("edited", commentBody: "Fixed typo", changedBodyFrom: "Fxied typo"));
+
+        await action.RunAsync();
+
+        discord.Verify(
+            d => d.SendMessageAsync(
+                It.IsAny<Uri>(),
+                It.Is<DiscordMessage>(m =>
+                    m.Embeds![0].Description!.StartsWith("```diff", StringComparison.Ordinal) &&
+                    m.Embeds![0].Description!.Contains("- Fxied typo") &&
+                    m.Embeds![0].Description!.Contains("+ Fixed typo"))),
+            Times.Once);
+    }
+
+    /// <summary>When an edited event has no body change (only other fields were edited), the plain body is shown.</summary>
+    [Fact]
+    public async Task RunAsyncEditedWithoutBodyChangeShowsPlainBody()
+    {
+        (Mock<IDiscordClient>? discord, Mock<IMessageCacheService>? cache, Mock<IGitHubUserMapManager>? userMap) = CreateMocks();
+
+        IssueCommentAction action = new(
+            discord.Object, cache.Object, userMap.Object,
+            Mock.Of<ILogger<IssueCommentAction>>(),
+            _webhookUri, "issue_comment",
+            MakeEvent("edited", commentBody: "LGTM"));
+
+        await action.RunAsync();
+
+        discord.Verify(
+            d => d.SendMessageAsync(
+                It.IsAny<Uri>(),
+                It.Is<DiscordMessage>(m => m.Embeds![0].Description == "LGTM")),
+            Times.Once);
+    }
+
+    /// <summary>When the diffed source text contains a run of 3 backticks on an edited event, the code fence does not break out.</summary>
+    [Fact]
+    public async Task RunAsyncEditedWithBacktickFenceInBodyEscapesFence()
+    {
+        (Mock<IDiscordClient>? discord, Mock<IMessageCacheService>? cache, Mock<IGitHubUserMapManager>? userMap) = CreateMocks();
+
+        IssueCommentAction action = new(
+            discord.Object, cache.Object, userMap.Object,
+            Mock.Of<ILogger<IssueCommentAction>>(),
+            _webhookUri, "issue_comment",
+            MakeEvent("edited", commentBody: "after ``` more", changedBodyFrom: "before ``` more"));
+
+        await action.RunAsync();
+
+        discord.Verify(
+            d => d.SendMessageAsync(
+                It.IsAny<Uri>(),
+                It.Is<DiscordMessage>(m => IsFenceIntact(m.Embeds![0].Description))),
+            Times.Once);
+    }
+
+    /// <summary>Checks that the description keeps its ```diff...``` shape and contains no fence-breakout backtick runs inside.</summary>
+    private static bool IsFenceIntact(string? description)
+    {
+        if (description is null ||
+            !description.StartsWith("```diff", StringComparison.Ordinal) ||
+            !description.EndsWith("```", StringComparison.Ordinal))
+            return false;
+
+        var inner = description.Substring("```diff\n".Length, description.Length - "```diff\n".Length - "```".Length);
+        return !inner.Contains("```", StringComparison.Ordinal);
+    }
+
+    /// <summary>When the diff is very long on an edited event, the description is truncated to stay within Discord's Embed limit.</summary>
+    [Fact]
+    public async Task RunAsyncEditedWithLongBodyChangeTruncatesDescription()
+    {
+        (Mock<IDiscordClient>? discord, Mock<IMessageCacheService>? cache, Mock<IGitHubUserMapManager>? userMap) = CreateMocks();
+
+        IssueCommentAction action = new(
+            discord.Object, cache.Object, userMap.Object,
+            Mock.Of<ILogger<IssueCommentAction>>(),
+            _webhookUri, "issue_comment",
+            MakeEvent("edited", commentBody: new string('y', 5000), changedBodyFrom: new string('x', 5000)));
+
+        await action.RunAsync();
+
+        discord.Verify(
+            d => d.SendMessageAsync(
+                It.IsAny<Uri>(),
+                It.Is<DiscordMessage>(m =>
+                    m.Embeds![0].Description!.Length <= 4096 &&
+                    m.Embeds![0].Description!.Contains("..."))),
             Times.Once);
     }
 

--- a/tests/PullRequestReviewCommentActionTests.cs
+++ b/tests/PullRequestReviewCommentActionTests.cs
@@ -35,13 +35,19 @@ public class PullRequestReviewCommentActionTests
     private static PullRequestReviewCommentEvent MakeEvent(
         string action = "created",
         string? path = null,
-        long commentId = 5001) =>
-        JsonSerializer.Deserialize<PullRequestReviewCommentEvent>(
+        long commentId = 5001,
+        string commentBody = "Looks good!",
+        string? changedBodyFrom = null)
+    {
+        var changesJson = action == "edited"
+            ? $$""","changes":{"body":{{(changedBodyFrom is not null ? $$"""{"from":"{{changedBodyFrom}}"}""" : "null")}}}"""
+            : "";
+        return JsonSerializer.Deserialize<PullRequestReviewCommentEvent>(
             $$"""
             {
                 "action":"{{action}}",
                 "comment":{{TestFixtures.ReviewCommentJson(
-                    commentId, "Looks good!",
+                    commentId, commentBody,
                     path ?? "src/file.cs",
                     $"https://github.com/test/repo/pull/10#discussion_r{commentId}")}},
                 "pull_request":{{TestFixtures.SimplePrJson(
@@ -49,10 +55,11 @@ public class PullRequestReviewCommentActionTests
                     "https://github.com/test/repo/pull/10",
                     "pr-author", 20)}},
                 "repository":{{TestFixtures.RepoJson("test/repo","https://github.com/test/repo")}},
-                "sender":{{TestFixtures.UserJson("reviewer",30)}}
+                "sender":{{TestFixtures.UserJson("reviewer",30)}}{{changesJson}}
             }
             """,
             OctokitJsonOptions.Value)!;
+    }
 
     /// <summary>The title of the created event contains "commented on" and the PR number.</summary>
     [Fact]
@@ -155,6 +162,107 @@ public class PullRequestReviewCommentActionTests
         await action.RunAsync();
 
         cache.Verify(c => c.GetAsync(_webhookUri, "test/repo-pr-review-comment-5001"), Times.Once);
+    }
+
+    /// <summary>When the body actually changed on an edited event, the description becomes a diff code block.</summary>
+    [Fact]
+    public async Task RunAsyncEditedWithBodyChangeShowsDiff()
+    {
+        (Mock<IDiscordClient>? discord, Mock<IMessageCacheService>? cache, Mock<IGitHubUserMapManager>? userMap) = CreateMocks();
+
+        PullRequestReviewCommentAction action = new(
+            discord.Object, cache.Object, userMap.Object,
+            Mock.Of<ILogger<PullRequestReviewCommentAction>>(),
+            _webhookUri, "pull_request_review_comment",
+            MakeEvent("edited", commentBody: "Fixed typo", changedBodyFrom: "Fxied typo"));
+
+        await action.RunAsync();
+
+        discord.Verify(
+            d => d.SendMessageAsync(
+                It.IsAny<Uri>(),
+                It.Is<DiscordMessage>(m =>
+                    m.Embeds![0].Description!.StartsWith("```diff", StringComparison.Ordinal) &&
+                    m.Embeds![0].Description!.Contains("- Fxied typo") &&
+                    m.Embeds![0].Description!.Contains("+ Fixed typo"))),
+            Times.Once);
+    }
+
+    /// <summary>When an edited event has no body change (only other fields were edited), the plain body is shown.</summary>
+    [Fact]
+    public async Task RunAsyncEditedWithoutBodyChangeShowsPlainBody()
+    {
+        (Mock<IDiscordClient>? discord, Mock<IMessageCacheService>? cache, Mock<IGitHubUserMapManager>? userMap) = CreateMocks();
+
+        PullRequestReviewCommentAction action = new(
+            discord.Object, cache.Object, userMap.Object,
+            Mock.Of<ILogger<PullRequestReviewCommentAction>>(),
+            _webhookUri, "pull_request_review_comment",
+            MakeEvent("edited", commentBody: "Looks good!"));
+
+        await action.RunAsync();
+
+        discord.Verify(
+            d => d.SendMessageAsync(
+                It.IsAny<Uri>(),
+                It.Is<DiscordMessage>(m => m.Embeds![0].Description == "Looks good!")),
+            Times.Once);
+    }
+
+    /// <summary>When the diffed source text contains a run of 3 backticks on an edited event, the code fence does not break out.</summary>
+    [Fact]
+    public async Task RunAsyncEditedWithBacktickFenceInBodyEscapesFence()
+    {
+        (Mock<IDiscordClient>? discord, Mock<IMessageCacheService>? cache, Mock<IGitHubUserMapManager>? userMap) = CreateMocks();
+
+        PullRequestReviewCommentAction action = new(
+            discord.Object, cache.Object, userMap.Object,
+            Mock.Of<ILogger<PullRequestReviewCommentAction>>(),
+            _webhookUri, "pull_request_review_comment",
+            MakeEvent("edited", commentBody: "after ``` more", changedBodyFrom: "before ``` more"));
+
+        await action.RunAsync();
+
+        discord.Verify(
+            d => d.SendMessageAsync(
+                It.IsAny<Uri>(),
+                It.Is<DiscordMessage>(m => IsFenceIntact(m.Embeds![0].Description))),
+            Times.Once);
+    }
+
+    /// <summary>Checks that the description keeps its ```diff...``` shape and contains no fence-breakout backtick runs inside.</summary>
+    private static bool IsFenceIntact(string? description)
+    {
+        if (description is null ||
+            !description.StartsWith("```diff", StringComparison.Ordinal) ||
+            !description.EndsWith("```", StringComparison.Ordinal))
+            return false;
+
+        var inner = description.Substring("```diff\n".Length, description.Length - "```diff\n".Length - "```".Length);
+        return !inner.Contains("```", StringComparison.Ordinal);
+    }
+
+    /// <summary>When the diff is very long on an edited event, the description is truncated to stay within Discord's Embed limit.</summary>
+    [Fact]
+    public async Task RunAsyncEditedWithLongBodyChangeTruncatesDescription()
+    {
+        (Mock<IDiscordClient>? discord, Mock<IMessageCacheService>? cache, Mock<IGitHubUserMapManager>? userMap) = CreateMocks();
+
+        PullRequestReviewCommentAction action = new(
+            discord.Object, cache.Object, userMap.Object,
+            Mock.Of<ILogger<PullRequestReviewCommentAction>>(),
+            _webhookUri, "pull_request_review_comment",
+            MakeEvent("edited", commentBody: new string('y', 5000), changedBodyFrom: new string('x', 5000)));
+
+        await action.RunAsync();
+
+        discord.Verify(
+            d => d.SendMessageAsync(
+                It.IsAny<Uri>(),
+                It.Is<DiscordMessage>(m =>
+                    m.Embeds![0].Description!.Length <= 4096 &&
+                    m.Embeds![0].Description!.Contains("..."))),
+            Times.Once);
     }
 
     /// <summary>When the PR author is mapped to Discord, the message is sent with a mention.</summary>


### PR DESCRIPTION
## Summary

Adds diff display for `issue_comment` and `pull_request_review_comment` webhook events when a comment is edited, mirroring the existing title-diff pattern already used in `IssuesAction` for issue title edits.

## Changes

- `IssueCommentAction` / `PullRequestReviewCommentAction`: when `action == "edited"` and the comment body actually changed, the Discord embed description now shows a unified diff of the old vs. new text instead of just the new body.
- Added `BaseAction.BuildDiffDescription`, a shared helper that:
  - caps the diff length so the assembled description stays under Discord's 4096-character embed description limit.
  - neutralizes triple-backtick sequences in the diffed comment text so an edited comment body cannot break out of the surrounding ` ```diff ` code fence.
- Added unit tests covering the diff-on-edit behavior, the plain-body-on-unrelated-edit fallback, the length cap, and the backtick-fence-escape behavior for both actions.

Closes #2664