### PR TITLE
chore: add .worktreeinclude for local dev files

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+src/local.settings.json
+data/


### PR DESCRIPTION
## Summary

Adds a `.worktreeinclude` file listing local-only, gitignored files that should still be copied when creating new git worktrees for this repository.

## Patterns added

- `src/local.settings.json`
- `data/`

## Evidence

- `.gitignore` excludes both `local.settings.json` (Azure Functions local config) and `data/` (user-managed JSON files).
- `README.md`: required env vars (e.g. `GITHUB_WEBHOOK_SECRET`, `AzureWebJobsStorage`) are set in `src/local.settings.json`.
- `CLAUDE.md`: "All keys are read via `IConfiguration`. Required keys must be set in `local.settings.json` / Azure app settings."
- `src/Managers/MuteManager.cs:15` — `GetDefaultFilePath() => "data/mutes.json"`.
- `src/Managers/GitHubUserMapManager.cs:24` — `GetDefaultFilePath() => "data/github-user-map.json"`.

No `.env.example`/`local.settings.json.example` template exists in the repo, so these files are typically created manually per the README's env-var table; they are needed to run/test the project locally and are good `.worktreeinclude` candidates.

Related: https://github.com/book000/book000/issues/132
